### PR TITLE
fix: 修复窗口状态保存写入顺序

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,6 +1,5 @@
 import { app, BrowserWindow, globalShortcut, ipcMain, screen } from 'electron'
 import { existsSync, readFileSync, writeFileSync } from 'node:fs'
-import { writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 
 interface WindowState {
@@ -154,18 +153,6 @@ function getCurrentWindowState(): WindowState | null {
   }
 }
 
-async function saveWindowStateAsync(): Promise<void> {
-  const state = getCurrentWindowState()
-
-  if (!state) return
-
-  try {
-    await writeFile(getWindowStatePath(), JSON.stringify(state, null, 2), 'utf-8')
-  } catch (error) {
-    console.error('[HeartDock] failed to save window state:', error)
-  }
-}
-
 function saveWindowStateSync(): void {
   const state = getCurrentWindowState()
 
@@ -185,7 +172,7 @@ function scheduleSaveWindowState(): void {
 
   saveWindowStateTimer = setTimeout(() => {
     saveWindowStateTimer = null
-    void saveWindowStateAsync()
+    saveWindowStateSync()
   }, 300)
 }
 


### PR DESCRIPTION
## 本次修改

- 移除窗口状态保存中的异步写入竞争
- 保留窗口移动和缩放后的防抖保存逻辑
- 防抖触发后改为同步保存窗口状态
- 关闭窗口时仍立即保存最后窗口状态
- 避免旧保存动作覆盖最后关闭前的位置和大小

## 测试

- 已测试关闭后记住最后关闭前的位置
- 已测试关闭后记住最后关闭前的大小
- 已测试应用可以正常启动
- 已测试拖动窗口无明显卡顿

## 关联 Issue

Closes #10 