### PR TITLE
feat: 增加心率数据源模式

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,10 +1,12 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState, type KeyboardEvent } from 'react'
 import {
   HeartDockConfig,
+  HeartRateSourceMode,
   ThemePresetId,
   applyThemePreset,
   createDefaultConfig,
   loadConfig,
+  normalizeBpm,
   saveConfig,
   themePresets
 } from './config'
@@ -15,10 +17,27 @@ function getColorForBpm(bpm: number, config: HeartDockConfig): string {
   return rule?.color ?? '#ffffff'
 }
 
+function getSourceLabel(sourceMode: HeartRateSourceMode): string {
+  if (sourceMode === 'manual') {
+    return '手动'
+  }
+
+  return '模拟'
+}
+
 function App() {
+  const initialConfigRef = useRef<HeartDockConfig | null>(null)
+
+  if (initialConfigRef.current === null) {
+    initialConfigRef.current = loadConfig()
+  }
+
   const sourceRef = useRef(new MockHeartRateSource())
-  const [bpm, setBpm] = useState(78)
-  const [config, setConfig] = useState<HeartDockConfig>(() => loadConfig())
+  const [bpm, setBpm] = useState(() => normalizeBpm(initialConfigRef.current?.manualBpm ?? 78))
+  const [config, setConfig] = useState<HeartDockConfig>(() => initialConfigRef.current ?? loadConfig())
+  const [manualInput, setManualInput] = useState(() =>
+    String(normalizeBpm(initialConfigRef.current?.manualBpm ?? 78))
+  )
 
   const bpmColor = useMemo(() => getColorForBpm(bpm, config), [bpm, config])
   const currentTheme = useMemo(
@@ -29,6 +48,10 @@ function App() {
   useEffect(() => {
     saveConfig(config)
   }, [config])
+
+  useEffect(() => {
+    setManualInput(String(normalizeBpm(config.manualBpm)))
+  }, [config.manualBpm])
 
   useEffect(() => {
     window.heartdock.setAlwaysOnTop(config.alwaysOnTop)
@@ -47,12 +70,21 @@ function App() {
   }, [])
 
   useEffect(() => {
+    if (config.heartRateSourceMode === 'manual') {
+      setBpm(normalizeBpm(config.manualBpm))
+      return
+    }
+
+    if (config.mockPaused) {
+      return
+    }
+
     const timer = window.setInterval(() => {
       setBpm(sourceRef.current.next())
     }, config.refreshIntervalMs)
 
     return () => window.clearInterval(timer)
-  }, [config.refreshIntervalMs])
+  }, [config.heartRateSourceMode, config.manualBpm, config.mockPaused, config.refreshIntervalMs])
 
   const updateConfig = <K extends keyof HeartDockConfig>(key: K, value: HeartDockConfig[K]): void => {
     setConfig((current) => ({ ...current, [key]: value }))
@@ -62,12 +94,77 @@ function App() {
     setConfig((current) => applyThemePreset(current, themeId))
   }
 
+  const handleSourceModeChange = (sourceMode: HeartRateSourceMode): void => {
+    setConfig((current) => {
+      if (sourceMode === 'manual') {
+        const manualBpm = normalizeBpm(current.manualBpm)
+
+        setBpm(manualBpm)
+        setManualInput(String(manualBpm))
+
+        return {
+          ...current,
+          heartRateSourceMode: sourceMode,
+          manualBpm
+        }
+      }
+
+      return {
+        ...current,
+        heartRateSourceMode: sourceMode
+      }
+    })
+  }
+
+  const handleManualInputChange = (value: string): void => {
+    setManualInput(value)
+  }
+
+  const applyManualBpm = (): void => {
+    const trimmed = manualInput.trim()
+
+    if (!trimmed) {
+      const fallback = normalizeBpm(config.manualBpm)
+      setManualInput(String(fallback))
+      setBpm(fallback)
+      updateConfig('manualBpm', fallback)
+      return
+    }
+
+    const parsed = Number(trimmed)
+
+    if (!Number.isFinite(parsed)) {
+      const fallback = normalizeBpm(config.manualBpm)
+      setManualInput(String(fallback))
+      setBpm(fallback)
+      updateConfig('manualBpm', fallback)
+      return
+    }
+
+    const nextBpm = normalizeBpm(parsed)
+
+    setManualInput(String(nextBpm))
+    setBpm(nextBpm)
+    updateConfig('manualBpm', nextBpm)
+  }
+
+  const handleManualInputKeyDown = (event: KeyboardEvent<HTMLInputElement>): void => {
+    if (event.key === 'Enter') {
+      applyManualBpm()
+    }
+  }
+
   const handleResetConfig = (): void => {
     const confirmed = window.confirm('确定要重置所有显示设置吗？')
 
     if (!confirmed) return
 
-    setConfig(createDefaultConfig())
+    const nextConfig = createDefaultConfig()
+    const nextBpm = normalizeBpm(nextConfig.manualBpm)
+
+    setBpm(nextBpm)
+    setManualInput(String(nextBpm))
+    setConfig(nextConfig)
   }
 
   return (
@@ -79,7 +176,7 @@ function App() {
         }}
       >
         <div className="top-row">
-          <span className="badge">模拟</span>
+          <span className="badge">{getSourceLabel(config.heartRateSourceMode)}</span>
 
           <div className="window-actions no-drag">
             <button
@@ -114,6 +211,52 @@ function App() {
 
         {config.showSettings && (
           <div className="settings-panel no-drag">
+            <label>
+              数据源
+              <select
+                value={config.heartRateSourceMode}
+                onChange={(event) => handleSourceModeChange(event.target.value as HeartRateSourceMode)}
+              >
+                <option value="mock">模拟心率</option>
+                <option value="manual">手动输入</option>
+              </select>
+            </label>
+
+            {config.heartRateSourceMode === 'mock' && (
+              <div className="source-panel">
+                <button
+                  className="secondary-button"
+                  type="button"
+                  onClick={() => updateConfig('mockPaused', !config.mockPaused)}
+                >
+                  {config.mockPaused ? '继续模拟心率' : '暂停模拟心率'}
+                </button>
+                <p className="hint">
+                  模拟模式会按照刷新间隔自动生成心率，适合测试悬浮窗样式和颜色变化。
+                </p>
+              </div>
+            )}
+
+            {config.heartRateSourceMode === 'manual' && (
+              <label>
+                手动心率
+                <input
+                  type="number"
+                  min="30"
+                  max="240"
+                  step="1"
+                  value={manualInput}
+                  onChange={(event) => handleManualInputChange(event.target.value)}
+                  onBlur={applyManualBpm}
+                  onKeyDown={handleManualInputKeyDown}
+                />
+              </label>
+            )}
+
+            {config.heartRateSourceMode === 'manual' && (
+              <p className="hint">手动模式会固定显示输入的 bpm，适合调试样式或临时展示。范围：30 - 240。</p>
+            )}
+
             <label>
               主题预设
               <select

--- a/src/renderer/src/config.ts
+++ b/src/renderer/src/config.ts
@@ -5,6 +5,7 @@ export interface ColorRule {
 }
 
 export type ThemePresetId = 'default' | 'transparent' | 'highContrast' | 'streamer'
+export type HeartRateSourceMode = 'mock' | 'manual'
 
 export interface ThemePreset {
   id: ThemePresetId
@@ -17,6 +18,9 @@ export interface ThemePreset {
 
 export interface HeartDockConfig {
   themePresetId: ThemePresetId
+  heartRateSourceMode: HeartRateSourceMode
+  mockPaused: boolean
+  manualBpm: number
   refreshIntervalMs: number
   fontSize: number
   backgroundOpacity: number
@@ -79,6 +83,9 @@ export const themePresets: ThemePreset[] = [
 
 export const defaultConfig: HeartDockConfig = {
   themePresetId: 'default',
+  heartRateSourceMode: 'mock',
+  mockPaused: false,
+  manualBpm: 78,
   refreshIntervalMs: 1000,
   fontSize: 64,
   backgroundOpacity: 0.24,
@@ -110,20 +117,31 @@ export function applyThemePreset(config: HeartDockConfig, themeId: ThemePresetId
   }
 }
 
+export function normalizeBpm(value: number): number {
+  if (!Number.isFinite(value)) {
+    return defaultConfig.manualBpm
+  }
+
+  return Math.min(Math.max(Math.round(value), 30), 240)
+}
+
 export function loadConfig(): HeartDockConfig {
   const raw = localStorage.getItem(CONFIG_KEY)
 
   if (!raw) {
-    return defaultConfig
+    return createDefaultConfig()
   }
 
   try {
+    const parsed = JSON.parse(raw) as Partial<HeartDockConfig>
+
     return {
-      ...defaultConfig,
-      ...JSON.parse(raw)
+      ...createDefaultConfig(),
+      ...parsed,
+      manualBpm: normalizeBpm(parsed.manualBpm ?? defaultConfig.manualBpm)
     }
   } catch {
-    return defaultConfig
+    return createDefaultConfig()
   }
 }
 

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -12,6 +12,8 @@ body,
   background: transparent;
   font-family:
     Inter,
+    "Microsoft YaHei UI",
+    "Microsoft YaHei",
     ui-sans-serif,
     system-ui,
     -apple-system,
@@ -35,19 +37,26 @@ select {
 
 .no-drag,
 input,
-button {
+button,
+select {
   -webkit-app-region: no-drag;
 }
 
 .overlay-card {
   width: 100%;
   min-height: 100%;
-  padding: 14px;
-  border: 1px solid rgba(255, 255, 255, 0.16);
-  border-radius: 22px;
+  padding: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  border-radius: 26px;
   color: white;
-  backdrop-filter: blur(16px);
-  box-shadow: 0 18px 45px rgba(0, 0, 0, 0.34);
+  background:
+    radial-gradient(circle at 50% 12%, rgba(56, 189, 248, 0.12), transparent 34%),
+    radial-gradient(circle at 18% 88%, rgba(244, 114, 182, 0.08), transparent 28%),
+    rgba(15, 23, 42, 0.58);
+  backdrop-filter: blur(18px);
+  box-shadow:
+    0 22px 60px rgba(0, 0, 0, 0.36),
+    inset 0 1px 0 rgba(255, 255, 255, 0.06);
 }
 
 .top-row {
@@ -57,99 +66,221 @@ button {
 }
 
 .badge {
-  padding: 3px 8px;
+  padding: 4px 10px;
   border: 1px solid rgba(255, 255, 255, 0.24);
   border-radius: 999px;
-  color: rgba(255, 255, 255, 0.82);
-  font-size: 11px;
+  color: rgba(255, 255, 255, 0.88);
+  background: rgba(15, 23, 42, 0.48);
+  font-size: 12px;
   letter-spacing: 0.08em;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+}
+
+.window-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
 }
 
 .icon-button {
-  width: 28px;
-  height: 28px;
+  display: grid;
+  width: 34px;
+  height: 34px;
+  place-items: center;
   border: 0;
   border-radius: 999px;
   color: white;
   background: rgba(255, 255, 255, 0.12);
   cursor: pointer;
+  transition:
+    transform 0.16s ease,
+    background 0.16s ease,
+    box-shadow 0.16s ease;
 }
 
 .icon-button:hover {
+  transform: translateY(-1px);
   background: rgba(255, 255, 255, 0.2);
+  box-shadow: 0 8px 22px rgba(0, 0, 0, 0.22);
+}
+
+.icon-button:active {
+  transform: translateY(0) scale(0.96);
+}
+
+.close-button {
+  font-size: 24px;
+  line-height: 1;
+}
+
+.close-button:hover {
+  background: rgba(248, 113, 113, 0.28);
 }
 
 .heart-row {
   display: flex;
   align-items: baseline;
   justify-content: center;
-  gap: 10px;
-  margin: 4px 0 6px;
+  gap: 12px;
+  margin: 14px 0 18px;
 }
 
 .heart {
-  font-size: 32px;
-  filter: drop-shadow(0 0 12px currentColor);
+  font-size: 34px;
+  filter: drop-shadow(0 0 14px currentColor);
   animation: pulse 1.15s ease-in-out infinite;
 }
 
 .bpm {
-  font-weight: 800;
-  line-height: 1;
+  font-weight: 850;
+  line-height: 0.92;
   letter-spacing: -0.08em;
-  text-shadow: 0 0 20px currentColor;
-  transition: color 0.2s ease, font-size 0.2s ease;
+  text-shadow: 0 0 24px currentColor;
+  transition:
+    color 0.2s ease,
+    font-size 0.2s ease,
+    text-shadow 0.2s ease;
 }
 
 .unit {
-  color: rgba(255, 255, 255, 0.76);
-  font-size: 18px;
-  font-weight: 600;
+  color: rgba(255, 255, 255, 0.78);
+  font-size: 20px;
+  font-weight: 700;
 }
 
 .settings-panel {
   display: grid;
-  gap: 8px;
-  padding: 10px;
-  border-radius: 16px;
-  background: rgba(15, 23, 42, 0.62);
+  gap: 10px;
+  padding: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  border-radius: 20px;
+  background:
+    linear-gradient(180deg, rgba(15, 23, 42, 0.78), rgba(15, 23, 42, 0.66)),
+    rgba(15, 23, 42, 0.7);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.04),
+    0 12px 28px rgba(0, 0, 0, 0.16);
 }
 
 .settings-panel label {
   display: grid;
-  grid-template-columns: 88px 1fr;
+  grid-template-columns: 112px 1fr;
   align-items: center;
-  gap: 8px;
-  color: rgba(255, 255, 255, 0.78);
-  font-size: 12px;
+  gap: 12px;
+  color: rgba(255, 255, 255, 0.82);
+  font-size: 14px;
 }
 
-.settings-panel input[type='number'] {
+.settings-panel input[type='number'],
+.settings-panel select {
   width: 100%;
-  padding: 4px 6px;
-  border: 1px solid rgba(255, 255, 255, 0.18);
-  border-radius: 8px;
+  height: 36px;
+  padding: 6px 10px;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  border-radius: 12px;
   color: white;
-  background: rgba(255, 255, 255, 0.08);
+  outline: none;
+  background: rgba(15, 23, 42, 0.72);
+  transition:
+    border-color 0.16s ease,
+    box-shadow 0.16s ease,
+    background 0.16s ease;
+}
+
+.settings-panel input[type='number']:focus,
+.settings-panel select:focus {
+  border-color: rgba(56, 189, 248, 0.88);
+  background: rgba(15, 23, 42, 0.9);
+  box-shadow:
+    0 0 0 3px rgba(56, 189, 248, 0.16),
+    0 0 22px rgba(56, 189, 248, 0.16);
 }
 
 .settings-panel select {
+  cursor: pointer;
+}
+
+.settings-panel input[type='range'] {
   width: 100%;
-  padding: 4px 6px;
-  border: 1px solid rgba(255, 255, 255, 0.18);
-  border-radius: 8px;
-  color: white;
-  background: rgba(15, 23, 42, 0.92);
+  height: 8px;
+  accent-color: #38bdf8;
+  cursor: pointer;
 }
 
 .checkbox-row {
-  grid-template-columns: 18px 1fr !important;
+  grid-template-columns: 22px 1fr !important;
+}
+
+.checkbox-row input {
+  width: 16px;
+  height: 16px;
+  accent-color: #60a5fa;
+  cursor: pointer;
+}
+
+.source-panel {
+  display: grid;
+  gap: 8px;
+  padding: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  border-radius: 14px;
+  background: rgba(30, 41, 59, 0.42);
+}
+
+.secondary-button,
+.reset-button {
+  height: 36px;
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  border-radius: 12px;
+  color: rgba(255, 255, 255, 0.92);
+  background: rgba(255, 255, 255, 0.1);
+  cursor: pointer;
+  transition:
+    transform 0.16s ease,
+    border-color 0.16s ease,
+    background 0.16s ease,
+    box-shadow 0.16s ease;
+}
+
+.secondary-button:hover,
+.reset-button:hover {
+  transform: translateY(-1px);
+  border-color: rgba(96, 165, 250, 0.58);
+  background: rgba(96, 165, 250, 0.16);
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.22);
+}
+
+.secondary-button:active,
+.reset-button:active {
+  transform: translateY(0) scale(0.98);
+}
+
+.reset-button {
+  margin-top: 4px;
+}
+
+.click-through-status {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 9px 10px;
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  border-radius: 14px;
+  color: rgba(255, 255, 255, 0.82);
+  background: rgba(30, 41, 59, 0.36);
+  font-size: 14px;
+}
+
+.click-through-status strong {
+  color: #f8fafc;
+  font-size: 16px;
 }
 
 .hint {
   margin: 0;
-  color: rgba(255, 255, 255, 0.55);
-  font-size: 11px;
+  color: rgba(226, 232, 240, 0.62);
+  font-size: 12px;
+  line-height: 1.55;
 }
 
 @keyframes pulse {
@@ -161,19 +292,4 @@ button {
   50% {
     transform: scale(1.16);
   }
-}
-
-.window-actions {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.close-button {
-  font-size: 22px;
-  line-height: 1;
-}
-
-.close-button:hover {
-  background: rgba(248, 113, 113, 0.25);
 }


### PR DESCRIPTION
## 本次修改

- 增加心率数据源模式配置
- 支持模拟心率模式
- 支持手动输入心率模式
- 支持暂停/继续模拟心率
- 设置面板中增加数据源切换
- 修复手动心率输入时被立即限制导致无法正常输入的问题
- 优化悬浮窗设置面板、按钮、输入框和下拉框样式
- 为后续 BLE 心率设备接入预留数据源结构

## 测试

- 已测试应用可以正常启动
- 已测试模拟心率会自动变化
- 已测试暂停/继续模拟心率
- 已测试手动输入 80 / 120 / 145 可以正常显示
- 已测试低于 30 会修正为 30
- 已测试高于 240 会修正为 240
- 已测试关闭后重新打开可以记住数据源模式和手动心率
- 已测试设置按钮、关闭按钮、主题切换和重置显示设置正常

## 关联 Issue

Closes #12