### PR TITLE
feat: 添加实验性 BLE 心率数据源

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -267,6 +267,23 @@ function createOverlayWindow(): void {
   overlayWindow.webContents.on('did-finish-load', () => {
     console.log('[HeartDock] renderer loaded')
   })
+  
+  overlayWindow.webContents.on('select-bluetooth-device', (event, deviceList, callback) => {
+  event.preventDefault()
+
+  const selectedDevice = deviceList.find((device) => Boolean(device.deviceName)) ?? deviceList[0]
+
+  if (!selectedDevice) {
+    return
+  }
+
+  console.log(
+    '[HeartDock] selected BLE device:',
+    selectedDevice.deviceName || selectedDevice.deviceId
+  )
+
+  callback(selectedDevice.deviceId)
+})
 
   overlayWindow.webContents.on('did-fail-load', (_event, errorCode, errorDescription, validatedURL) => {
     console.error('[HeartDock] renderer failed to load:', errorCode, errorDescription, validatedURL)

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -12,6 +12,8 @@ import {
 } from './config'
 import { MockHeartRateSource } from './core/MockHeartRateSource'
 
+type BleConnectionStatus = 'idle' | 'connecting' | 'connected' | 'failed'
+
 function getColorForBpm(bpm: number, config: HeartDockConfig): string {
   const rule = config.colorRules.find((item) => bpm >= item.min && bpm <= item.max)
   return rule?.color ?? '#ffffff'
@@ -20,6 +22,10 @@ function getColorForBpm(bpm: number, config: HeartDockConfig): string {
 function getSourceLabel(sourceMode: HeartRateSourceMode): string {
   if (sourceMode === 'manual') {
     return '手动'
+  }
+
+  if (sourceMode === 'ble') {
+    return 'BLE'
   }
 
   return '模拟'
@@ -38,6 +44,9 @@ function App() {
   const [manualInput, setManualInput] = useState(() =>
     String(normalizeBpm(initialConfigRef.current?.manualBpm ?? 78))
   )
+  const [bleStatus, setBleStatus] = useState<BleConnectionStatus>('idle')
+  const [bleDeviceName, setBleDeviceName] = useState('')
+  const [bleMessage, setBleMessage] = useState('尚未连接 BLE 心率设备。')
 
   const bpmColor = useMemo(() => getColorForBpm(bpm, config), [bpm, config])
   const currentTheme = useMemo(
@@ -75,6 +84,10 @@ function App() {
       return
     }
 
+    if (config.heartRateSourceMode === 'ble') {
+      return
+    }
+
     if (config.mockPaused) {
       return
     }
@@ -94,7 +107,35 @@ function App() {
     setConfig((current) => applyThemePreset(current, themeId))
   }
 
+  const getBleStatusText = (): string => {
+    if (bleStatus === 'connecting') {
+      return '连接中'
+    }
+
+    if (bleStatus === 'connected') {
+      return '已连接'
+    }
+
+    if (bleStatus === 'failed') {
+      return '连接失败'
+    }
+
+    return '未连接'
+  }
+
+  const handleConnectBleDevice = (): void => {
+    setBleStatus('failed')
+    setBleDeviceName('')
+    setBleMessage('BLE 连接功能将在下一步接入 Web Bluetooth。当前版本已先预留连接入口和状态显示。')
+  }
+
   const handleSourceModeChange = (sourceMode: HeartRateSourceMode): void => {
+    if (sourceMode === 'ble') {
+      setBleStatus('idle')
+      setBleDeviceName('')
+      setBleMessage('尚未连接 BLE 心率设备。')
+    }
+
     setConfig((current) => {
       if (sourceMode === 'manual') {
         const manualBpm = normalizeBpm(current.manualBpm)
@@ -164,6 +205,9 @@ function App() {
 
     setBpm(nextBpm)
     setManualInput(String(nextBpm))
+    setBleStatus('idle')
+    setBleDeviceName('')
+    setBleMessage('尚未连接 BLE 心率设备。')
     setConfig(nextConfig)
   }
 
@@ -219,6 +263,7 @@ function App() {
               >
                 <option value="mock">模拟心率</option>
                 <option value="manual">手动输入</option>
+                <option value="ble">BLE 心率设备（实验）</option>
               </select>
             </label>
 
@@ -255,6 +300,33 @@ function App() {
 
             {config.heartRateSourceMode === 'manual' && (
               <p className="hint">手动模式会固定显示输入的 bpm，适合调试样式或临时展示。范围：30 - 240。</p>
+            )}
+
+            {config.heartRateSourceMode === 'ble' && (
+              <div className="source-panel">
+                <div className="ble-status-row">
+                  <span>连接状态</span>
+                  <strong>{getBleStatusText()}</strong>
+                </div>
+
+                {bleDeviceName && (
+                  <div className="ble-status-row">
+                    <span>设备名称</span>
+                    <strong>{bleDeviceName}</strong>
+                  </div>
+                )}
+
+                <button
+                  className="secondary-button"
+                  type="button"
+                  disabled={bleStatus === 'connecting'}
+                  onClick={handleConnectBleDevice}
+                >
+                  {bleStatus === 'connecting' ? '正在连接...' : '连接心率设备'}
+                </button>
+
+                <p className="hint">{bleMessage}</p>
+              </div>
             )}
 
             <label>

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState, type KeyboardEvent } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent } from 'react'
 import {
   HeartDockConfig,
   HeartRateSourceMode,
@@ -7,12 +7,49 @@ import {
   createDefaultConfig,
   loadConfig,
   normalizeBpm,
+  normalizeRefreshIntervalMs,
   saveConfig,
   themePresets
 } from './config'
 import { MockHeartRateSource } from './core/MockHeartRateSource'
 
 type BleConnectionStatus = 'idle' | 'connecting' | 'connected' | 'failed'
+
+interface BleCharacteristic {
+  value?: DataView
+  startNotifications: () => Promise<BleCharacteristic>
+  stopNotifications?: () => Promise<BleCharacteristic>
+  addEventListener: (type: 'characteristicvaluechanged', listener: (event: Event) => void) => void
+  removeEventListener: (type: 'characteristicvaluechanged', listener: (event: Event) => void) => void
+}
+
+interface BleService {
+  getCharacteristic: (characteristic: string) => Promise<BleCharacteristic>
+}
+
+interface BleServer {
+  connected?: boolean
+  connect: () => Promise<BleServer>
+  disconnect?: () => void
+  getPrimaryService: (service: string) => Promise<BleService>
+}
+
+interface BleDevice {
+  id: string
+  name?: string
+  gatt?: BleServer
+  addEventListener: (type: 'gattserverdisconnected', listener: (event: Event) => void) => void
+  removeEventListener: (type: 'gattserverdisconnected', listener: (event: Event) => void) => void
+}
+
+interface NavigatorWithBluetooth extends Navigator {
+  bluetooth?: {
+    requestDevice: (options: {
+      filters: Array<{ services: string[] }>
+      optionalServices?: string[]
+    }) => Promise<BleDevice>
+  }
+}
 
 function getColorForBpm(bpm: number, config: HeartDockConfig): string {
   const rule = config.colorRules.find((item) => bpm >= item.min && bpm <= item.max)
@@ -31,6 +68,49 @@ function getSourceLabel(sourceMode: HeartRateSourceMode): string {
   return '模拟'
 }
 
+function parseHeartRateMeasurement(value: DataView): number | null {
+  if (value.byteLength < 2) {
+    return null
+  }
+
+  const flags = value.getUint8(0)
+  const is16BitHeartRate = (flags & 0x01) === 0x01
+
+  if (is16BitHeartRate) {
+    if (value.byteLength < 3) {
+      return null
+    }
+
+    return normalizeBpm(value.getUint16(1, true))
+  }
+
+  return normalizeBpm(value.getUint8(1))
+}
+
+function getBleDeviceDisplayName(device: BleDevice): string {
+  const fallbackName = `BLE 心率设备 ${device.id.slice(0, 8)}`
+  const rawName = device.name?.trim()
+
+  if (!rawName) {
+    return fallbackName
+  }
+
+  const cleanedName = rawName
+    .replace(/\uFFFD/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+
+  if (!cleanedName) {
+    return fallbackName
+  }
+
+  if (cleanedName.toLowerCase() === 'xiaomi') {
+    return 'Xiaomi 心率设备'
+  }
+
+  return cleanedName
+}
+
 function App() {
   const initialConfigRef = useRef<HeartDockConfig | null>(null)
 
@@ -39,10 +119,17 @@ function App() {
   }
 
   const sourceRef = useRef(new MockHeartRateSource())
+  const sourceModeRef = useRef<HeartRateSourceMode>(initialConfigRef.current.heartRateSourceMode)
+  const bleDeviceRef = useRef<BleDevice | null>(null)
+  const bleCharacteristicRef = useRef<BleCharacteristic | null>(null)
+
   const [bpm, setBpm] = useState(() => normalizeBpm(initialConfigRef.current?.manualBpm ?? 78))
   const [config, setConfig] = useState<HeartDockConfig>(() => initialConfigRef.current ?? loadConfig())
   const [manualInput, setManualInput] = useState(() =>
     String(normalizeBpm(initialConfigRef.current?.manualBpm ?? 78))
+  )
+  const [refreshIntervalInput, setRefreshIntervalInput] = useState(() =>
+    String(normalizeRefreshIntervalMs(initialConfigRef.current?.refreshIntervalMs ?? 1000))
   )
   const [bleStatus, setBleStatus] = useState<BleConnectionStatus>('idle')
   const [bleDeviceName, setBleDeviceName] = useState('')
@@ -55,12 +142,20 @@ function App() {
   )
 
   useEffect(() => {
+    sourceModeRef.current = config.heartRateSourceMode
+  }, [config.heartRateSourceMode])
+
+  useEffect(() => {
     saveConfig(config)
   }, [config])
 
   useEffect(() => {
     setManualInput(String(normalizeBpm(config.manualBpm)))
   }, [config.manualBpm])
+
+  useEffect(() => {
+    setRefreshIntervalInput(String(normalizeRefreshIntervalMs(config.refreshIntervalMs)))
+  }, [config.refreshIntervalMs])
 
   useEffect(() => {
     window.heartdock.setAlwaysOnTop(config.alwaysOnTop)
@@ -92,9 +187,13 @@ function App() {
       return
     }
 
+    const safeRefreshIntervalMs = normalizeRefreshIntervalMs(config.refreshIntervalMs)
+
+    setBpm(sourceRef.current.next())
+
     const timer = window.setInterval(() => {
       setBpm(sourceRef.current.next())
-    }, config.refreshIntervalMs)
+    }, safeRefreshIntervalMs)
 
     return () => window.clearInterval(timer)
   }, [config.heartRateSourceMode, config.manualBpm, config.mockPaused, config.refreshIntervalMs])
@@ -123,13 +222,153 @@ function App() {
     return '未连接'
   }
 
-  const handleConnectBleDevice = (): void => {
-    setBleStatus('failed')
-    setBleDeviceName('')
-    setBleMessage('BLE 连接功能将在下一步接入 Web Bluetooth。当前版本已先预留连接入口和状态显示。')
+  const handleBleMeasurement = useCallback((event: Event): void => {
+    if (sourceModeRef.current !== 'ble') {
+      return
+    }
+
+    const characteristic = event.target as BleCharacteristic | null
+    const value = characteristic?.value
+
+    if (!value) {
+      return
+    }
+
+    const nextBpm = parseHeartRateMeasurement(value)
+
+    if (nextBpm === null) {
+      setBleMessage('收到心率数据，但暂时无法解析。')
+      return
+    }
+
+    setBpm(nextBpm)
+    setBleStatus('connected')
+    setBleMessage(`正在接收 BLE 心率数据：${nextBpm} bpm`)
+  }, [])
+
+  const handleBleDisconnected = useCallback((): void => {
+    setBleStatus('idle')
+    setBleMessage('BLE 设备已断开连接。可以重新点击连接心率设备。')
+    bleCharacteristicRef.current = null
+    bleDeviceRef.current = null
+  }, [])
+
+  const disconnectBleDevice = useCallback(
+    async (message = 'BLE 连接已关闭。'): Promise<void> => {
+      const characteristic = bleCharacteristicRef.current
+      const device = bleDeviceRef.current
+
+      setBleStatus('idle')
+      setBleDeviceName('')
+      setBleMessage(message)
+
+      if (characteristic) {
+        characteristic.removeEventListener('characteristicvaluechanged', handleBleMeasurement)
+
+        try {
+          await characteristic.stopNotifications?.()
+        } catch (error) {
+          console.warn('[HeartDock] failed to stop BLE notifications:', error)
+        }
+      }
+
+      if (device) {
+        device.removeEventListener('gattserverdisconnected', handleBleDisconnected)
+
+        try {
+          if (device.gatt?.connected) {
+            device.gatt.disconnect?.()
+          }
+        } catch (error) {
+          console.warn('[HeartDock] failed to disconnect BLE device:', error)
+        }
+      }
+
+      bleCharacteristicRef.current = null
+      bleDeviceRef.current = null
+    },
+    [handleBleDisconnected, handleBleMeasurement]
+  )
+
+  const handleConnectBleDevice = async (): Promise<void> => {
+    const bluetooth = (navigator as NavigatorWithBluetooth).bluetooth
+
+    if (!bluetooth) {
+      setBleStatus('failed')
+      setBleDeviceName('')
+      setBleMessage('当前环境不支持 Web Bluetooth。请确认 Electron / Chromium 环境和系统蓝牙支持。')
+      return
+    }
+
+    try {
+      await disconnectBleDevice('正在准备重新连接 BLE 心率设备。')
+
+      setBleStatus('connecting')
+      setBleMessage('正在请求 BLE 心率设备，请确保设备已开启心率广播或标准心率服务。')
+
+      const device = await bluetooth.requestDevice({
+        filters: [{ services: ['heart_rate'] }],
+        optionalServices: ['heart_rate']
+      })
+
+      if (sourceModeRef.current !== 'ble') {
+        return
+      }
+
+      bleDeviceRef.current = device
+      setBleDeviceName(getBleDeviceDisplayName(device))
+      setBleMessage('已选择设备，正在连接 GATT 服务。')
+
+      device.addEventListener('gattserverdisconnected', handleBleDisconnected)
+
+      const server = await device.gatt?.connect()
+
+      if (!server) {
+        throw new Error('无法连接设备 GATT 服务。')
+      }
+
+      if (sourceModeRef.current !== 'ble') {
+        server.disconnect?.()
+        return
+      }
+
+      const service = await server.getPrimaryService('heart_rate')
+      const characteristic = await service.getCharacteristic('heart_rate_measurement')
+
+      bleCharacteristicRef.current = characteristic
+      characteristic.addEventListener('characteristicvaluechanged', handleBleMeasurement)
+
+      await characteristic.startNotifications()
+
+      setBleStatus('connected')
+      setBleMessage('已连接 BLE 心率设备，等待心率数据通知。')
+    } catch (error) {
+      if (sourceModeRef.current !== 'ble') {
+        return
+      }
+
+      setBleStatus('failed')
+
+      if (error instanceof Error) {
+        setBleMessage(`BLE 连接失败：${error.message}`)
+      } else {
+        setBleMessage('BLE 连接失败：未知错误。')
+      }
+    }
   }
 
   const handleSourceModeChange = (sourceMode: HeartRateSourceMode): void => {
+    sourceModeRef.current = sourceMode
+
+    if (sourceMode === 'mock') {
+      sourceRef.current = new MockHeartRateSource()
+      setBpm(sourceRef.current.next())
+    }
+
+    if (config.heartRateSourceMode === 'ble' && sourceMode !== 'ble') {
+      void disconnectBleDevice('已切换到其他数据源，BLE 连接已关闭。')
+    }
+
     if (sourceMode === 'ble') {
       setBleStatus('idle')
       setBleDeviceName('')
@@ -195,6 +434,37 @@ function App() {
     }
   }
 
+  const applyRefreshIntervalMs = (): void => {
+    const trimmed = refreshIntervalInput.trim()
+
+    if (!trimmed) {
+      const fallback = normalizeRefreshIntervalMs(config.refreshIntervalMs)
+      setRefreshIntervalInput(String(fallback))
+      updateConfig('refreshIntervalMs', fallback)
+      return
+    }
+
+    const parsed = Number(trimmed)
+
+    if (!Number.isFinite(parsed)) {
+      const fallback = normalizeRefreshIntervalMs(config.refreshIntervalMs)
+      setRefreshIntervalInput(String(fallback))
+      updateConfig('refreshIntervalMs', fallback)
+      return
+    }
+
+    const nextRefreshIntervalMs = normalizeRefreshIntervalMs(parsed)
+
+    setRefreshIntervalInput(String(nextRefreshIntervalMs))
+    updateConfig('refreshIntervalMs', nextRefreshIntervalMs)
+  }
+
+  const handleRefreshIntervalKeyDown = (event: KeyboardEvent<HTMLInputElement>): void => {
+    if (event.key === 'Enter') {
+      applyRefreshIntervalMs()
+    }
+  }
+
   const handleResetConfig = (): void => {
     const confirmed = window.confirm('确定要重置所有显示设置吗？')
 
@@ -203,11 +473,14 @@ function App() {
     const nextConfig = createDefaultConfig()
     const nextBpm = normalizeBpm(nextConfig.manualBpm)
 
+    void disconnectBleDevice('已重置显示设置，BLE 连接已关闭。')
+
+    sourceModeRef.current = nextConfig.heartRateSourceMode
+    sourceRef.current = new MockHeartRateSource()
+
     setBpm(nextBpm)
     setManualInput(String(nextBpm))
-    setBleStatus('idle')
-    setBleDeviceName('')
-    setBleMessage('尚未连接 BLE 心率设备。')
+    setRefreshIntervalInput(String(normalizeRefreshIntervalMs(nextConfig.refreshIntervalMs)))
     setConfig(nextConfig)
   }
 
@@ -316,14 +589,24 @@ function App() {
                   </div>
                 )}
 
-                <button
-                  className="secondary-button"
-                  type="button"
-                  disabled={bleStatus === 'connecting'}
-                  onClick={handleConnectBleDevice}
-                >
-                  {bleStatus === 'connecting' ? '正在连接...' : '连接心率设备'}
-                </button>
+                {bleStatus === 'connected' ? (
+                  <button
+                    className="secondary-button danger-button"
+                    type="button"
+                    onClick={() => void disconnectBleDevice('BLE 连接已手动关闭。')}
+                  >
+                    断开 BLE 连接
+                  </button>
+                ) : (
+                  <button
+                    className="secondary-button"
+                    type="button"
+                    disabled={bleStatus === 'connecting'}
+                    onClick={handleConnectBleDevice}
+                  >
+                    {bleStatus === 'connecting' ? '正在连接...' : '连接心率设备'}
+                  </button>
+                )}
 
                 <p className="hint">{bleMessage}</p>
               </div>
@@ -361,9 +644,12 @@ function App() {
               <input
                 type="number"
                 min="250"
+                max="10000"
                 step="250"
-                value={config.refreshIntervalMs}
-                onChange={(event) => updateConfig('refreshIntervalMs', Number(event.target.value))}
+                value={refreshIntervalInput}
+                onChange={(event) => setRefreshIntervalInput(event.target.value)}
+                onBlur={applyRefreshIntervalMs}
+                onKeyDown={handleRefreshIntervalKeyDown}
               />
             </label>
 

--- a/src/renderer/src/config.ts
+++ b/src/renderer/src/config.ts
@@ -125,6 +125,16 @@ export function normalizeBpm(value: number): number {
   return Math.min(Math.max(Math.round(value), 30), 240)
 }
 
+export function normalizeRefreshIntervalMs(value: number): number {
+  if (!Number.isFinite(value)) {
+    return defaultConfig.refreshIntervalMs
+  }
+
+  const roundedValue = Math.round(value / 250) * 250
+
+  return Math.min(Math.max(roundedValue, 250), 10000)
+}
+
 export function loadConfig(): HeartDockConfig {
   const raw = localStorage.getItem(CONFIG_KEY)
 
@@ -138,7 +148,10 @@ export function loadConfig(): HeartDockConfig {
     return {
       ...createDefaultConfig(),
       ...parsed,
-      manualBpm: normalizeBpm(parsed.manualBpm ?? defaultConfig.manualBpm)
+      manualBpm: normalizeBpm(parsed.manualBpm ?? defaultConfig.manualBpm),
+      refreshIntervalMs: normalizeRefreshIntervalMs(
+        parsed.refreshIntervalMs ?? defaultConfig.refreshIntervalMs
+      )
     }
   } catch {
     return createDefaultConfig()
@@ -152,6 +165,8 @@ export function saveConfig(config: HeartDockConfig): void {
 export function createDefaultConfig(): HeartDockConfig {
   return {
     ...defaultConfig,
+    refreshIntervalMs: normalizeRefreshIntervalMs(defaultConfig.refreshIntervalMs),
+    manualBpm: normalizeBpm(defaultConfig.manualBpm),
     colorRules: [...defaultConfig.colorRules]
   }
 }

--- a/src/renderer/src/config.ts
+++ b/src/renderer/src/config.ts
@@ -5,7 +5,7 @@ export interface ColorRule {
 }
 
 export type ThemePresetId = 'default' | 'transparent' | 'highContrast' | 'streamer'
-export type HeartRateSourceMode = 'mock' | 'manual'
+export type HeartRateSourceMode = 'mock' | 'manual' | 'ble'
 
 export interface ThemePreset {
   id: ThemePresetId

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -262,6 +262,15 @@ select {
   box-shadow: none;
 }
 
+.danger-button {
+  color: #fecaca;
+}
+
+.danger-button:hover {
+  border-color: rgba(248, 113, 113, 0.58);
+  background: rgba(248, 113, 113, 0.16);
+}
+
 .reset-button {
   margin-top: 4px;
 }

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -255,14 +255,23 @@ select {
   transform: translateY(0) scale(0.98);
 }
 
+.secondary-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.62;
+  transform: none;
+  box-shadow: none;
+}
+
 .reset-button {
   margin-top: 4px;
 }
 
-.click-through-status {
+.click-through-status,
+.ble-status-row {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 12px;
   padding: 9px 10px;
   border: 1px solid rgba(148, 163, 184, 0.14);
   border-radius: 14px;
@@ -271,9 +280,22 @@ select {
   font-size: 14px;
 }
 
-.click-through-status strong {
+.click-through-status strong,
+.ble-status-row strong {
   color: #f8fafc;
   font-size: 16px;
+}
+
+.ble-status-row {
+  padding: 8px 10px;
+  border-radius: 12px;
+  color: rgba(226, 232, 240, 0.78);
+  background: rgba(15, 23, 42, 0.36);
+  font-size: 13px;
+}
+
+.ble-status-row strong {
+  font-size: 14px;
 }
 
 .hint {


### PR DESCRIPTION
## 本次修改

- 数据源模式中增加 BLE 心率设备（实验）选项
- 增加 BLE 连接状态显示
- 增加连接心率设备按钮
- 接入 Web Bluetooth 请求标准 Heart Rate Service 设备
- 连接 GATT 服务并订阅 Heart Rate Measurement 通知
- 解析 BLE 心率数据并更新悬浮窗 bpm
- 显示 BLE 设备名称
- 清理部分 BLE 设备名称乱码
- 增加断开 BLE 连接按钮
- 修复从 BLE 切换到模拟/手动后心率数字互相覆盖的问题
- 修复刷新间隔输入时导致模拟心率忽快忽慢的问题

## 测试

- 已测试应用可以正常启动
- 已测试 BLE 模式可以连接心率设备
- 已测试可以同步手表实时心率
- 已测试设备名称乱码清理
- 已测试连接成功后只显示“断开 BLE 连接”
- 已测试断开后恢复显示“连接心率设备”
- 已测试从 BLE 切回模拟心率后，BLE 不再覆盖数字
- 已测试从 BLE 切回手动输入后，手动 bpm 不再被覆盖
- 已测试模拟心率刷新间隔正常
- 已测试刷新间隔输入过小或过大时会自动修正
- 已测试模拟心率、手动输入、BLE 三种数据源切换正常

## 说明

本任务优先支持标准 BLE Heart Rate Service：

- Heart Rate Service: 0x180D
- Heart Rate Measurement: 0x2A37

这不是小米手环私有协议适配，暂不处理 auth key、私有认证和厂商专有命令。

## 关联 Issue

Closes #16 