### PR TITLE
feat: 支持纯享模式拖动位置

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -130,8 +130,9 @@ function loadWindowState(): WindowState {
     const parsedState = JSON.parse(raw) as WindowState
 
     return sanitizeWindowState({
-      ...DEFAULT_WINDOW_STATE,
-      ...parsedState
+      ...parsedState,
+      width: DEFAULT_WINDOW_STATE.width,
+      height: DEFAULT_WINDOW_STATE.height
     })
   } catch {
     return centerInPrimaryDisplay(DEFAULT_WINDOW_STATE.width, DEFAULT_WINDOW_STATE.height)
@@ -146,8 +147,8 @@ function getCurrentWindowState(): WindowState | null {
   const bounds = overlayWindow.getBounds()
 
   return {
-    width: bounds.width,
-    height: bounds.height,
+    width: DEFAULT_WINDOW_STATE.width,
+    height: DEFAULT_WINDOW_STATE.height,
     x: bounds.x,
     y: bounds.y
   }
@@ -220,6 +221,70 @@ function registerIpcHandlers(): void {
     overlayWindow?.close()
   })
 
+  ipcMain.handle('overlay:move-window-by', (_event, deltaX: number, deltaY: number) => {
+    if (!overlayWindow || overlayWindow.isDestroyed()) {
+      return false
+    }
+
+    if (!Number.isFinite(deltaX) || !Number.isFinite(deltaY)) {
+      return false
+    }
+
+    const bounds = overlayWindow.getBounds()
+
+    overlayWindow.setBounds(
+      {
+        ...bounds,
+        x: bounds.x + Math.round(deltaX),
+        y: bounds.y + Math.round(deltaY)
+      },
+      false
+    )
+
+    scheduleSaveWindowState()
+
+    return true
+  })
+
+  ipcMain.handle('overlay:get-window-bounds', () => {
+    if (!overlayWindow || overlayWindow.isDestroyed()) {
+      return null
+    }
+
+    return overlayWindow.getBounds()
+  })
+
+  ipcMain.handle(
+    'overlay:set-window-bounds',
+    (_event, bounds: { x: number; y: number; width: number; height: number }) => {
+      if (!overlayWindow || overlayWindow.isDestroyed()) {
+        return false
+      }
+
+      if (
+        !Number.isFinite(bounds.x) ||
+        !Number.isFinite(bounds.y) ||
+        !Number.isFinite(bounds.width) ||
+        !Number.isFinite(bounds.height)
+      ) {
+        return false
+      }
+
+      const nextBounds = {
+        x: Math.round(bounds.x),
+        y: Math.round(bounds.y),
+        width: Math.max(Math.round(bounds.width), MIN_WINDOW_STATE.width),
+        height: Math.max(Math.round(bounds.height), MIN_WINDOW_STATE.height)
+      }
+
+      overlayWindow.setBounds(nextBounds, false)
+      scheduleSaveWindowState()
+
+      return true
+    }
+  )
+
+
   ipcMain.handle('set-always-on-top', (_event, value: boolean) => {
     return setOverlayAlwaysOnTop(value)
   })
@@ -270,21 +335,21 @@ function createOverlayWindow(): void {
   })
   
   overlayWindow.webContents.on('select-bluetooth-device', (event, deviceList, callback) => {
-  event.preventDefault()
+    event.preventDefault()
 
-  const selectedDevice = deviceList.find((device) => Boolean(device.deviceName)) ?? deviceList[0]
+    const selectedDevice = deviceList.find((device) => Boolean(device.deviceName)) ?? deviceList[0]
 
-  if (!selectedDevice) {
-    return
-  }
+    if (!selectedDevice) {
+      return
+    }
 
-  console.log(
-    '[HeartDock] selected BLE device:',
-    selectedDevice.deviceName || selectedDevice.deviceId
-  )
+    console.log(
+      '[HeartDock] selected BLE device:',
+      selectedDevice.deviceName || selectedDevice.deviceId
+    )
 
-  callback(selectedDevice.deviceId)
-})
+    callback(selectedDevice.deviceId)
+  })
 
   overlayWindow.webContents.on('did-fail-load', (_event, errorCode, errorDescription, validatedURL) => {
     console.error('[HeartDock] renderer failed to load:', errorCode, errorDescription, validatedURL)

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,10 +1,22 @@
 import { contextBridge, ipcRenderer } from 'electron'
 
+interface HeartDockWindowBounds {
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
 contextBridge.exposeInMainWorld('heartdock', {
   setAlwaysOnTop: (enabled: boolean) => ipcRenderer.invoke('overlay:set-always-on-top', enabled),
   setClickThrough: (enabled: boolean) => ipcRenderer.invoke('overlay:set-click-through', enabled),
   getClickThrough: () => ipcRenderer.invoke('overlay:get-click-through'),
   closeWindow: () => ipcRenderer.invoke('overlay:close-window'),
+  getWindowBounds: () => ipcRenderer.invoke('overlay:get-window-bounds'),
+  setWindowBounds: (bounds: HeartDockWindowBounds) =>
+    ipcRenderer.invoke('overlay:set-window-bounds', bounds),
+  moveWindowBy: (deltaX: number, deltaY: number) =>
+    ipcRenderer.invoke('overlay:move-window-by', deltaX, deltaY),
   onClickThroughChanged: (callback: (enabled: boolean) => void) => {
     const listener = (_event: Electron.IpcRendererEvent, enabled: boolean) => callback(enabled)
     ipcRenderer.on('overlay:click-through-changed', listener)

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,4 +1,13 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type MouseEvent as ReactMouseEvent
+} from 'react'
+
 import {
   HeartDockConfig,
   HeartRateSourceMode,
@@ -115,7 +124,14 @@ function App() {
   const initialConfigRef = useRef<HeartDockConfig | null>(null)
 
   if (initialConfigRef.current === null) {
-    initialConfigRef.current = loadConfig()
+    const loadedConfig = loadConfig()
+
+    initialConfigRef.current = {
+      ...loadedConfig,
+      showSettings: true,
+      pureDisplay: false,
+      clickThrough: false
+    }
   }
 
   const sourceRef = useRef(new MockHeartRateSource())
@@ -123,6 +139,16 @@ function App() {
   const bleDeviceRef = useRef<BleDevice | null>(null)
   const bleCharacteristicRef = useRef<BleCharacteristic | null>(null)
   const pureHeartRef = useRef<HTMLDivElement | null>(null)
+  const normalWindowBoundsRef = useRef<HeartDockWindowBounds | null>(null)
+  const pureDragStateRef = useRef({
+    isDragging: false,
+    lastScreenX: 0,
+    lastScreenY: 0,
+    totalDeltaX: 0,
+    totalDeltaY: 0
+  })
+
+  const pureDragMovedRef = useRef(false)
 
   const [bpm, setBpm] = useState(() => normalizeBpm(initialConfigRef.current?.manualBpm ?? 78))
   const [config, setConfig] = useState<HeartDockConfig>(() => initialConfigRef.current ?? loadConfig())
@@ -135,8 +161,8 @@ function App() {
   const [bleStatus, setBleStatus] = useState<BleConnectionStatus>('idle')
   const [bleDeviceName, setBleDeviceName] = useState('')
   const [bleMessage, setBleMessage] = useState(
-  '尚未连接 BLE 心率设备。请先开启 Windows 蓝牙，并确保心率设备正在广播标准心率服务。连接前心率将显示为 -- bpm。'
-)
+    '尚未连接 BLE 心率设备。请先开启 Windows 蓝牙，并确保心率设备正在广播标准心率服务。连接前心率将显示为 -- bpm。'
+  )
 
   const shouldShowBlePlaceholder =
     config.heartRateSourceMode === 'ble' && bleStatus !== 'connected'
@@ -259,12 +285,99 @@ function App() {
     setConfig((current) => applyThemePreset(current, themeId))
   }
 
-  const handleTogglePureDisplay = (): void => {
+  const handleTogglePureDisplay = async (): Promise<void> => {
+    if (!config.pureDisplay) {
+      normalWindowBoundsRef.current = await window.heartdock.getWindowBounds()
+
+      setConfig((current) => ({
+        ...current,
+        pureDisplay: true,
+        showSettings: false
+      }))
+
+      return
+    }
+
+    const normalWindowBounds = normalWindowBoundsRef.current
+
     setConfig((current) => ({
       ...current,
-      pureDisplay: !current.pureDisplay,
-      showSettings: current.pureDisplay ? true : false
+      pureDisplay: false,
+      showSettings: true
     }))
+
+    if (normalWindowBounds) {
+      window.setTimeout(() => {
+        void window.heartdock.setWindowBounds(normalWindowBounds)
+      }, 0)
+    }
+  }
+
+
+  const handlePureDisplayDoubleClick = (): void => {
+    if (pureDragMovedRef.current) {
+      return
+    }
+
+    void handleTogglePureDisplay()
+  }
+
+  const handlePureDisplayMouseDown = (event: ReactMouseEvent<HTMLDivElement>): void => {
+    if (event.button !== 0) {
+      return
+    }
+
+    event.preventDefault()
+
+    pureDragStateRef.current = {
+      isDragging: true,
+      lastScreenX: event.screenX,
+      lastScreenY: event.screenY,
+      totalDeltaX: 0,
+      totalDeltaY: 0
+    }
+
+    window.heartdock.setClickThrough(false)
+
+    const handleMouseMove = (moveEvent: MouseEvent): void => {
+      const dragState = pureDragStateRef.current
+
+      if (!dragState.isDragging) {
+        return
+      }
+
+      const deltaX = moveEvent.screenX - dragState.lastScreenX
+      const deltaY = moveEvent.screenY - dragState.lastScreenY
+
+      if (deltaX === 0 && deltaY === 0) {
+        return
+      }
+
+      dragState.lastScreenX = moveEvent.screenX
+      dragState.lastScreenY = moveEvent.screenY
+      dragState.totalDeltaX += Math.abs(deltaX)
+      dragState.totalDeltaY += Math.abs(deltaY)
+
+      if (dragState.totalDeltaX + dragState.totalDeltaY > 4) {
+        pureDragMovedRef.current = true
+      }
+
+      void window.heartdock.moveWindowBy(deltaX, deltaY)
+    }
+
+    const handleMouseUp = (): void => {
+      pureDragStateRef.current.isDragging = false
+
+      window.removeEventListener('mousemove', handleMouseMove)
+      window.removeEventListener('mouseup', handleMouseUp)
+
+      window.setTimeout(() => {
+        pureDragMovedRef.current = false
+      }, 180)
+    }
+
+    window.addEventListener('mousemove', handleMouseMove)
+    window.addEventListener('mouseup', handleMouseUp)
   }
 
   const getBleStatusText = (): string => {
@@ -408,19 +521,19 @@ function App() {
         return
       }
 
-if (error instanceof Error && error.message.includes('User cancelled')) {
-  setBleStatus('idle')
-  setBleMessage('未选择 BLE 心率设备。请确认 Windows 蓝牙已开启，设备正在广播心率服务，然后重新点击连接。')
-  return
-}
+      if (error instanceof Error && error.message.includes('User cancelled')) {
+        setBleStatus('idle')
+        setBleMessage('未选择 BLE 心率设备。请确认 Windows 蓝牙已开启，设备正在广播心率服务，然后重新点击连接。')
+        return
+      }
 
-setBleStatus('failed')
+      setBleStatus('failed')
 
-if (error instanceof Error) {
-  setBleMessage(`BLE 连接失败：${error.message}。请检查 Windows 蓝牙是否已开启，设备是否正在广播标准心率服务。`)
-} else {
-  setBleMessage('BLE 连接失败：未知错误。请检查 Windows 蓝牙是否已开启，设备是否正在广播标准心率服务。')
-}
+      if (error instanceof Error) {
+        setBleMessage(`BLE 连接失败：${error.message}。请检查 Windows 蓝牙是否已开启，设备是否正在广播标准心率服务。`)
+      } else {
+        setBleMessage('BLE 连接失败：未知错误。请检查 Windows 蓝牙是否已开启，设备是否正在广播标准心率服务。')
+      }
     }
   }
 
@@ -544,6 +657,7 @@ if (error instanceof Error) {
 
     sourceModeRef.current = nextConfig.heartRateSourceMode
     sourceRef.current = new MockHeartRateSource()
+    normalWindowBoundsRef.current = null
 
     setBpm(nextBpm)
     setManualInput(String(nextBpm))
@@ -554,15 +668,19 @@ if (error instanceof Error) {
   return (
     <main className={`app-shell ${isPureDisplay ? 'pure-display-shell' : ''}`}>
       {isPureDisplay ? (
-        <section
-          className="pure-display-view no-drag"
-          onDoubleClick={handleTogglePureDisplay}
-        >
+        <section className="pure-display-view no-drag">
           <div
             ref={pureHeartRef}
             className="pure-heart-row"
+            title="按住拖动位置，双击退出纯享模式"
+            onMouseDown={handlePureDisplayMouseDown}
+            onDoubleClick={handlePureDisplayDoubleClick}
             onMouseEnter={() => window.heartdock.setClickThrough(false)}
-            onMouseLeave={() => window.heartdock.setClickThrough(true)}
+            onMouseLeave={() => {
+              if (!pureDragStateRef.current.isDragging) {
+                window.heartdock.setClickThrough(true)
+              }
+            }}
           >
             <span className="heart pure-heart" style={{ color: bpmColor }}>
               ♥
@@ -702,6 +820,38 @@ if (error instanceof Error) {
                 </div>
               )}
 
+              <div className="quick-options">
+                <label className="option-card">
+                  <input
+                    type="checkbox"
+                    checked={config.alwaysOnTop}
+                    onChange={(event) => updateConfig('alwaysOnTop', event.target.checked)}
+                  />
+                  <span className="option-content">
+                    <span className="option-title">始终置顶</span>
+                    <span className="option-desc">让 HeartDock 保持在其他窗口上方。</span>
+                  </span>
+                  <span className="option-switch" aria-hidden="true" />
+                </label>
+
+                <label className="option-card option-card-primary">
+                  <input
+                    type="checkbox"
+                    checked={config.pureDisplay}
+                    onChange={() => void handleTogglePureDisplay()}
+                  />
+                  <span className="option-content">
+                    <span className="option-title">纯享显示模式</span>
+                    <span className="option-desc">隐藏设置面板，只保留心率本体显示。</span>
+                  </span>
+                  <span className="option-switch" aria-hidden="true" />
+                </label>
+              </div>
+
+              <p className="hint">
+                纯享模式下可以按住心率本体拖动位置，双击心率区域退出纯享模式。
+              </p>
+
               <label>
                 主题预设
                 <select
@@ -745,28 +895,6 @@ if (error instanceof Error) {
 
               <p className="hint">
                 背景透明度会在隐藏设置面板后生效。设置面板打开时会使用不透明背景，避免桌面内容透出影响可读性。
-              </p>
-
-              <label className="checkbox-row">
-                <input
-                  type="checkbox"
-                  checked={config.alwaysOnTop}
-                  onChange={(event) => updateConfig('alwaysOnTop', event.target.checked)}
-                />
-                始终置顶
-              </label>
-
-              <label className="checkbox-row">
-                <input
-                  type="checkbox"
-                  checked={config.pureDisplay}
-                  onChange={handleTogglePureDisplay}
-                />
-                纯享显示模式
-              </label>
-
-              <p className="hint">
-                开启后会隐藏设置面板和窗口装饰，只保留心率显示。双击心率数字区域可退出纯享模式。
               </p>
 
               <div className="click-through-status">

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -358,6 +358,134 @@ select {
   transform: scale(0.94);
 }
 
+
+.quick-options {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.option-card {
+  position: relative;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 12px;
+  align-items: center;
+  min-height: 74px;
+  padding: 12px 14px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 18px;
+  background:
+    linear-gradient(180deg, rgba(30, 41, 59, 0.86), rgba(15, 23, 42, 0.92));
+  cursor: pointer;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.05),
+    0 10px 22px rgba(0, 0, 0, 0.12);
+  transition:
+    transform 0.16s ease,
+    border-color 0.16s ease,
+    background 0.16s ease,
+    box-shadow 0.16s ease;
+}
+
+.option-card:hover {
+  transform: translateY(-1px);
+  border-color: rgba(125, 211, 252, 0.42);
+  background:
+    linear-gradient(180deg, rgba(30, 64, 105, 0.72), rgba(15, 23, 42, 0.94));
+  box-shadow:
+    0 12px 26px rgba(0, 0, 0, 0.16),
+    0 0 0 3px rgba(56, 189, 248, 0.08),
+    inset 0 1px 0 rgba(255, 255, 255, 0.06);
+}
+
+.option-card input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.option-content {
+  display: grid;
+  gap: 4px;
+}
+
+.option-title {
+  color: rgba(248, 250, 252, 0.96);
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.option-desc {
+  color: rgba(203, 213, 225, 0.62);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.option-switch {
+  position: relative;
+  width: 42px;
+  height: 24px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.92);
+  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.28);
+  transition:
+    border-color 0.16s ease,
+    background 0.16s ease,
+    box-shadow 0.16s ease;
+}
+
+.option-switch::before {
+  content: "";
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 16px;
+  height: 16px;
+  border-radius: 999px;
+  background: rgba(226, 232, 240, 0.92);
+  box-shadow: 0 2px 7px rgba(0, 0, 0, 0.26);
+  transition:
+    transform 0.16s ease,
+    background 0.16s ease;
+}
+
+.option-card input:checked ~ .option-switch {
+  border-color: rgba(96, 165, 250, 0.9);
+  background:
+    linear-gradient(180deg, rgba(59, 130, 246, 0.96), rgba(37, 99, 235, 0.96));
+  box-shadow:
+    0 0 0 3px rgba(59, 130, 246, 0.14),
+    inset 0 1px 0 rgba(255, 255, 255, 0.16);
+}
+
+.option-card input:checked ~ .option-switch::before {
+  transform: translateX(18px);
+  background: #ffffff;
+}
+
+.option-card:has(input:checked) {
+  border-color: rgba(96, 165, 250, 0.42);
+  background:
+    linear-gradient(180deg, rgba(30, 64, 105, 0.74), rgba(15, 23, 42, 0.94));
+}
+
+.option-card-primary:has(input:checked) {
+  border-color: rgba(74, 222, 128, 0.42);
+  background:
+    linear-gradient(180deg, rgba(20, 83, 45, 0.42), rgba(15, 23, 42, 0.94));
+}
+
+.option-card-primary input:checked ~ .option-switch {
+  border-color: rgba(74, 222, 128, 0.86);
+  background:
+    linear-gradient(180deg, rgba(34, 197, 94, 0.96), rgba(22, 163, 74, 0.96));
+  box-shadow:
+    0 0 0 3px rgba(34, 197, 94, 0.14),
+    inset 0 1px 0 rgba(255, 255, 255, 0.16);
+}
+
 .source-panel {
   display: grid;
   gap: 8px;
@@ -519,7 +647,7 @@ select {
   justify-content: center;
   gap: 12px;
   margin: 0;
-  cursor: pointer;
+  cursor: grab;
   user-select: none;
   pointer-events: auto;
   -webkit-app-region: no-drag;
@@ -546,6 +674,12 @@ select {
   font-weight: 700;
 }
 
+
+
+.pure-heart-row:active {
+  cursor: grabbing;
+}
+
 .pure-heart-row:hover .bpm,
 .pure-heart-row:hover .heart {
   filter: drop-shadow(0 0 18px currentColor);
@@ -563,6 +697,10 @@ select {
 }
 
 @media (max-width: 620px) {
+  .quick-options {
+    grid-template-columns: 1fr;
+  }
+
   .settings-panel {
     max-height: calc(100vh - 140px);
     padding: 12px;

--- a/src/renderer/src/vite-env.d.ts
+++ b/src/renderer/src/vite-env.d.ts
@@ -1,10 +1,20 @@
 /// <reference types="vite/client" />
 
+interface HeartDockWindowBounds {
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
 interface HeartDockApi {
   setAlwaysOnTop: (enabled: boolean) => Promise<boolean>
   setClickThrough: (enabled: boolean) => Promise<boolean>
   getClickThrough: () => Promise<boolean>
   closeWindow: () => Promise<void>
+  getWindowBounds: () => Promise<HeartDockWindowBounds | null>
+  setWindowBounds: (bounds: HeartDockWindowBounds) => Promise<boolean>
+  moveWindowBy: (deltaX: number, deltaY: number) => Promise<boolean>
   onClickThroughChanged: (callback: (enabled: boolean) => void) => () => void
 }
 


### PR DESCRIPTION
## 本次修改

- 支持纯享模式下按住心率本体拖动显示位置
- 保留双击心率区域退出纯享模式
- 进入纯享模式前记录普通设置窗口状态
- 退出纯享模式后恢复普通设置窗口位置和大小
- 启动时默认回到设置页面，避免上次处于纯享或点击穿透状态导致无法操作
- 将“始终置顶 / 纯享显示模式”调整为更靠前的卡片式开关
- 优化纯享模式相关交互提示
- 调整窗口状态保存策略：当前阶段固定设置窗口默认尺寸，仅保存窗口位置，避免透明窗口下缩放状态污染

## 测试

- 已测试普通设置页面正常打开
- 已测试开启纯享模式后只显示心率本体
- 已测试纯享模式下可以拖动心率位置
- 已测试双击心率区域可以退出纯享模式
- 已测试退出纯享模式后设置页面窗口恢复正常
- 已测试关闭后重新打开默认显示设置页面
- 已测试始终置顶和纯享显示模式卡片开关正常
- 已测试窗口不会再因为纯享拖动后变成异常尺寸
- 已运行 npm run typecheck