### PR TITLE
feat: 优化 BLE 断线重连体验

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -19,6 +19,7 @@ interface WindowBounds {
 let overlayWindow: BrowserWindow | null = null
 let clickThrough = false
 let saveWindowStateTimer: ReturnType<typeof setTimeout> | null = null
+let bluetoothSelectionTimer: ReturnType<typeof setTimeout> | null = null
 
 const MIN_WINDOW_STATE: WindowState = {
   width: 520,
@@ -130,9 +131,8 @@ function loadWindowState(): WindowState {
     const parsedState = JSON.parse(raw) as WindowState
 
     return sanitizeWindowState({
-      ...parsedState,
-      width: DEFAULT_WINDOW_STATE.width,
-      height: DEFAULT_WINDOW_STATE.height
+      ...DEFAULT_WINDOW_STATE,
+      ...parsedState
     })
   } catch {
     return centerInPrimaryDisplay(DEFAULT_WINDOW_STATE.width, DEFAULT_WINDOW_STATE.height)
@@ -147,8 +147,8 @@ function getCurrentWindowState(): WindowState | null {
   const bounds = overlayWindow.getBounds()
 
   return {
-    width: DEFAULT_WINDOW_STATE.width,
-    height: DEFAULT_WINDOW_STATE.height,
+    width: bounds.width,
+    height: bounds.height,
     x: bounds.x,
     y: bounds.y
   }
@@ -339,16 +339,30 @@ function createOverlayWindow(): void {
 
     const selectedDevice = deviceList.find((device) => Boolean(device.deviceName)) ?? deviceList[0]
 
-    if (!selectedDevice) {
+    if (selectedDevice) {
+      if (bluetoothSelectionTimer) {
+        clearTimeout(bluetoothSelectionTimer)
+        bluetoothSelectionTimer = null
+      }
+
+      console.log(
+        '[HeartDock] selected BLE device:',
+        selectedDevice.deviceName || selectedDevice.deviceId
+      )
+
+      callback(selectedDevice.deviceId)
       return
     }
 
-    console.log(
-      '[HeartDock] selected BLE device:',
-      selectedDevice.deviceName || selectedDevice.deviceId
-    )
+    if (bluetoothSelectionTimer) {
+      return
+    }
 
-    callback(selectedDevice.deviceId)
+    bluetoothSelectionTimer = setTimeout(() => {
+      bluetoothSelectionTimer = null
+      console.log('[HeartDock] no BLE heart rate device found, cancelling bluetooth selection')
+      callback('')
+    }, 8000)
   })
 
   overlayWindow.webContents.on('did-fail-load', (_event, errorCode, errorDescription, validatedURL) => {

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -138,6 +138,7 @@ function App() {
   const sourceModeRef = useRef<HeartRateSourceMode>(initialConfigRef.current.heartRateSourceMode)
   const bleDeviceRef = useRef<BleDevice | null>(null)
   const bleCharacteristicRef = useRef<BleCharacteristic | null>(null)
+  const isManualBleDisconnectRef = useRef(false)
   const pureHeartRef = useRef<HTMLDivElement | null>(null)
   const normalWindowBoundsRef = useRef<HeartDockWindowBounds | null>(null)
   const pureDragStateRef = useRef({
@@ -160,6 +161,7 @@ function App() {
   )
   const [bleStatus, setBleStatus] = useState<BleConnectionStatus>('idle')
   const [bleDeviceName, setBleDeviceName] = useState('')
+  const [hasBleReconnectDevice, setHasBleReconnectDevice] = useState(false)
   const [bleMessage, setBleMessage] = useState(
     '尚未连接 BLE 心率设备。请先开启 Windows 蓝牙，并确保心率设备正在广播标准心率服务。连接前心率将显示为 -- bpm。'
   )
@@ -313,7 +315,6 @@ function App() {
     }
   }
 
-
   const handlePureDisplayDoubleClick = (): void => {
     if (pureDragMovedRef.current) {
       return
@@ -421,78 +422,49 @@ function App() {
   }, [])
 
   const handleBleDisconnected = useCallback((): void => {
-    setBleStatus('idle')
-    setBleMessage('BLE 设备已断开连接。当前不再接收实时心率，可以重新点击连接心率设备。')
-    bleCharacteristicRef.current = null
-    bleDeviceRef.current = null
-  }, [])
-
-  const disconnectBleDevice = useCallback(
-    async (message = 'BLE 连接已关闭。'): Promise<void> => {
-      const characteristic = bleCharacteristicRef.current
-      const device = bleDeviceRef.current
-
-      setBleStatus('idle')
-      setBleDeviceName('')
-      setBleMessage(message)
-
-      if (characteristic) {
-        characteristic.removeEventListener('characteristicvaluechanged', handleBleMeasurement)
-
-        try {
-          await characteristic.stopNotifications?.()
-        } catch (error) {
-          console.warn('[HeartDock] failed to stop BLE notifications:', error)
-        }
-      }
-
-      if (device) {
-        device.removeEventListener('gattserverdisconnected', handleBleDisconnected)
-
-        try {
-          if (device.gatt?.connected) {
-            device.gatt.disconnect?.()
-          }
-        } catch (error) {
-          console.warn('[HeartDock] failed to disconnect BLE device:', error)
-        }
-      }
-
-      bleCharacteristicRef.current = null
-      bleDeviceRef.current = null
-    },
-    [handleBleDisconnected, handleBleMeasurement]
-  )
-
-  const handleConnectBleDevice = async (): Promise<void> => {
-    const bluetooth = (navigator as NavigatorWithBluetooth).bluetooth
-
-    if (!bluetooth) {
-      setBleStatus('failed')
-      setBleDeviceName('')
-      setBleMessage('当前环境不支持 Web Bluetooth。请确认 Electron / Chromium 环境和系统蓝牙支持。')
+    if (isManualBleDisconnectRef.current) {
+      isManualBleDisconnectRef.current = false
       return
     }
 
-    try {
-      await disconnectBleDevice('正在准备重新连接 BLE 心率设备。')
+    const device = bleDeviceRef.current
 
-      setBleStatus('connecting')
-      setBleMessage('正在请求 BLE 心率设备。请确认 Windows 蓝牙已开启，并让心率设备开启心率广播或标准 BLE Heart Rate Service。')
+    bleCharacteristicRef.current = null
+    setBleStatus('idle')
 
-      const device = await bluetooth.requestDevice({
-        filters: [{ services: ['heart_rate'] }],
-        optionalServices: ['heart_rate']
-      })
+    if (device) {
+      const displayName = getBleDeviceDisplayName(device)
 
+      setBleDeviceName(displayName)
+      setHasBleReconnectDevice(true)
+      setBleMessage(`BLE 设备已断开连接。可以点击“重新连接上次设备”尝试重新连接 ${displayName}。`)
+      return
+    }
+
+    setBleDeviceName('')
+    setHasBleReconnectDevice(false)
+    setBleMessage('BLE 设备已断开连接。当前不再接收实时心率，可以重新点击连接心率设备。')
+  }, [])
+
+  const connectBleDevice = useCallback(
+    async (device: BleDevice, isReconnect = false): Promise<void> => {
       if (sourceModeRef.current !== 'ble') {
         return
       }
 
-      bleDeviceRef.current = device
-      setBleDeviceName(getBleDeviceDisplayName(device))
-      setBleMessage('已选择设备，正在连接 GATT 服务。')
+      const displayName = getBleDeviceDisplayName(device)
+      const previousDevice = bleDeviceRef.current
 
+      if (previousDevice && previousDevice !== device) {
+        previousDevice.removeEventListener('gattserverdisconnected', handleBleDisconnected)
+      }
+
+      setBleStatus('connecting')
+      setBleDeviceName(displayName)
+      setHasBleReconnectDevice(true)
+      setBleMessage(isReconnect ? `正在重新连接 ${displayName}。` : '已选择设备，正在连接 GATT 服务。')
+
+      device.removeEventListener('gattserverdisconnected', handleBleDisconnected)
       device.addEventListener('gattserverdisconnected', handleBleDisconnected)
 
       const server = await device.gatt?.connect()
@@ -509,13 +481,94 @@ function App() {
       const service = await server.getPrimaryService('heart_rate')
       const characteristic = await service.getCharacteristic('heart_rate_measurement')
 
+      bleDeviceRef.current = device
       bleCharacteristicRef.current = characteristic
+      characteristic.removeEventListener('characteristicvaluechanged', handleBleMeasurement)
       characteristic.addEventListener('characteristicvaluechanged', handleBleMeasurement)
 
       await characteristic.startNotifications()
 
       setBleStatus('connected')
-      setBleMessage('已连接 BLE 心率设备，等待心率数据通知。')
+      setHasBleReconnectDevice(true)
+      setBleDeviceName(displayName)
+      setBleMessage(isReconnect ? `已重新连接 ${displayName}，等待心率数据通知。` : '已连接 BLE 心率设备，等待心率数据通知。')
+    },
+    [handleBleDisconnected, handleBleMeasurement]
+  )
+
+  const disconnectBleDevice = useCallback(
+    async (message = 'BLE 连接已关闭。', clearDevice = true): Promise<void> => {
+      const characteristic = bleCharacteristicRef.current
+      const device = bleDeviceRef.current
+
+      setBleStatus('idle')
+      setBleMessage(message)
+
+      if (clearDevice) {
+        setBleDeviceName('')
+        setHasBleReconnectDevice(false)
+      } else if (device) {
+        setBleDeviceName(getBleDeviceDisplayName(device))
+        setHasBleReconnectDevice(true)
+      }
+
+      if (characteristic) {
+        characteristic.removeEventListener('characteristicvaluechanged', handleBleMeasurement)
+
+        try {
+          await characteristic.stopNotifications?.()
+        } catch (error) {
+          console.warn('[HeartDock] failed to stop BLE notifications:', error)
+        }
+      }
+
+      if (device) {
+        if (clearDevice) {
+          device.removeEventListener('gattserverdisconnected', handleBleDisconnected)
+        }
+
+        try {
+          if (device.gatt?.connected) {
+            isManualBleDisconnectRef.current = true
+            device.gatt.disconnect?.()
+          }
+        } catch (error) {
+          isManualBleDisconnectRef.current = false
+          console.warn('[HeartDock] failed to disconnect BLE device:', error)
+        }
+      }
+
+      bleCharacteristicRef.current = null
+
+      if (clearDevice) {
+        bleDeviceRef.current = null
+        isManualBleDisconnectRef.current = false
+      }
+    },
+    [handleBleDisconnected, handleBleMeasurement]
+  )
+
+  const handleConnectBleDevice = async (): Promise<void> => {
+    const bluetooth = (navigator as NavigatorWithBluetooth).bluetooth
+
+    if (!bluetooth) {
+      setBleStatus('failed')
+      setBleDeviceName('')
+      setHasBleReconnectDevice(false)
+      setBleMessage('当前环境不支持 Web Bluetooth。请确认 Electron / Chromium 环境和系统蓝牙支持。')
+      return
+    }
+
+    try {
+      setBleStatus('connecting')
+      setBleMessage('正在请求 BLE 心率设备。请确认 Windows 蓝牙已开启，并让心率设备开启心率广播或标准 BLE Heart Rate Service。')
+
+      const device = await bluetooth.requestDevice({
+        filters: [{ services: ['heart_rate'] }],
+        optionalServices: ['heart_rate']
+      })
+
+      await connectBleDevice(device, false)
     } catch (error) {
       if (sourceModeRef.current !== 'ble') {
         return
@@ -523,7 +576,11 @@ function App() {
 
       if (error instanceof Error && error.message.includes('User cancelled')) {
         setBleStatus('idle')
-        setBleMessage('未选择 BLE 心率设备。请确认 Windows 蓝牙已开启，设备正在广播心率服务，然后重新点击连接。')
+        setBleMessage(
+          hasBleReconnectDevice
+            ? '未选择新的 BLE 心率设备。可以重新连接上次设备，或确认其他设备正在广播心率服务后再选择。'
+            : '未选择 BLE 心率设备。请确认 Windows 蓝牙已开启，设备正在广播心率服务，然后重新点击连接。'
+        )
         return
       }
 
@@ -533,6 +590,36 @@ function App() {
         setBleMessage(`BLE 连接失败：${error.message}。请检查 Windows 蓝牙是否已开启，设备是否正在广播标准心率服务。`)
       } else {
         setBleMessage('BLE 连接失败：未知错误。请检查 Windows 蓝牙是否已开启，设备是否正在广播标准心率服务。')
+      }
+    }
+  }
+
+  const handleReconnectBleDevice = async (): Promise<void> => {
+    const device = bleDeviceRef.current
+
+    if (!device) {
+      setHasBleReconnectDevice(false)
+      setBleStatus('idle')
+      setBleMessage('没有可重连的 BLE 心率设备。请点击“连接心率设备”重新选择设备。')
+      return
+    }
+
+    try {
+      await connectBleDevice(device, true)
+    } catch (error) {
+      if (sourceModeRef.current !== 'ble') {
+        return
+      }
+
+      setBleStatus('failed')
+      setHasBleReconnectDevice(true)
+
+      const displayName = getBleDeviceDisplayName(device)
+
+      if (error instanceof Error) {
+        setBleMessage(`重新连接 ${displayName} 失败：${error.message}。请确认设备仍在附近、蓝牙已开启，并且心率广播仍处于开启状态。`)
+      } else {
+        setBleMessage(`重新连接 ${displayName} 失败：未知错误。请确认设备仍在附近、蓝牙已开启，并且心率广播仍处于开启状态。`)
       }
     }
   }
@@ -552,6 +639,7 @@ function App() {
     if (sourceMode === 'ble') {
       setBleStatus('idle')
       setBleDeviceName('')
+      setHasBleReconnectDevice(false)
       setBleMessage('尚未连接 BLE 心率设备。请先开启 Windows 蓝牙，并确保心率设备正在广播标准心率服务。连接前心率将显示为 -- bpm。')
     }
 
@@ -805,6 +893,26 @@ function App() {
                     >
                       断开 BLE 连接
                     </button>
+                  ) : hasBleReconnectDevice ? (
+                    <>
+                      <button
+                        className="secondary-button"
+                        type="button"
+                        disabled={bleStatus === 'connecting'}
+                        onClick={handleReconnectBleDevice}
+                      >
+                        {bleStatus === 'connecting' ? '正在重连...' : '重新连接上次设备'}
+                      </button>
+
+                      <button
+                        className="secondary-button"
+                        type="button"
+                        disabled={bleStatus === 'connecting'}
+                        onClick={handleConnectBleDevice}
+                      >
+                        选择其他心率设备
+                      </button>
+                    </>
                   ) : (
                     <button
                       className="secondary-button"


### PR DESCRIPTION
## 本次修改

- BLE 意外断开后保留上一次设备信息
- 增加“重新连接上次设备”入口
- 支持在同一运行会话内快速重连上一次 BLE 心率设备
- 选择其他设备失败时保留上一次可重连设备
- 修复没有可用 BLE 设备时连接状态一直停在连接中的问题
- 手动断开 BLE 时清理设备引用
- 切换到模拟/手动模式时关闭并清理 BLE 连接
- 优化 BLE 断开和重连提示文案

## 测试

- 已测试 BLE 正常连接心率设备
- 已测试 BLE 断开后显示重新连接入口
- 已测试重新连接上次设备
- 已测试选择其他设备但无可用设备时不会一直卡在连接中
- 已测试选择其他设备失败后仍保留上一次重连入口
- 已测试手动断开后清理连接状态
- 已测试切换模拟/手动模式后 BLE 不再覆盖心率
- 已测试未连接时显示 `-- bpm`
- 已运行 npm run typecheck

## 关联 Issue

Closes #29