### PR TITLE
docs: 精简 README 并中文化文档

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,85 +1,64 @@
 # HeartDock
 
-HeartDock 是一个面向 Windows 的可自定义桌面心率悬浮窗工具。
+HeartDock 是一个面向 Windows 的桌面心率悬浮窗工具。
 
 它基于 Electron + React 构建，目标是提供一个轻量、清爽、可定制的心率显示窗口，适合桌面显示、直播、录屏叠加和日常观察心率变化。
 
-当前项目仍处于早期预发布阶段，但已经支持模拟心率、手动输入心率，以及实验性的标准 BLE 心率设备读取。
+当前项目处于早期预发布阶段，已经支持模拟心率、手动输入心率，以及实验性的标准 BLE 心率设备读取。
+
+---
+
+## 当前版本
+
+当前最新预发布版本：**v0.1.9**
+
+v0.1.9 主要优化了 BLE 心率设备断线后的重连体验：
+
+- BLE 意外断开后保留上一次设备信息
+- 支持重新连接上次 BLE 心率设备
+- 选择其他设备失败时不再一直停留在连接中
+- 手动断开和切换数据源时会清理 BLE 连接状态
 
 ---
 
 ## 功能特性
 
 - 桌面心率悬浮窗
-- 窗口始终置顶
+- 始终置顶
 - 模拟心率数据源
 - 手动输入心率数据源
 - 实验性 BLE 心率设备数据源
 - 支持标准 BLE Heart Rate Service
-- 支持实时显示 BLE 心率数据
-- 支持连接 / 断开 BLE 心率设备
-- 支持显示 BLE 连接状态
-- 支持清理部分 BLE 设备名称乱码
-- 自定义字体大小
-- 自定义刷新间隔
-- 根据 BPM 心率区间改变颜色
-- 背景透明度控制
-- 可选点击穿透模式
+- 支持 BLE 断开后的快速重连
+- 心率颜色随 BPM 区间变化
+- 字体大小和刷新间隔设置
+- 点击穿透模式
 - 纯享心率显示模式
-- 本地配置持久化
-- 主题预设切换
+- 纯享模式下拖动心率位置
+- 本地配置保存
 - 中文设置界面
-- 窗口位置和尺寸保存
-- 适合 GitHub 项目管理的基础结构
 
 ---
 
-## 当前状态
+## 快速开始
 
-HeartDock 当前处于 v0.1.x 早期预发布阶段。  
-目前已经完成基础桌面悬浮窗、主题预设、窗口状态保存、实验性 BLE 心率读取和纯享心率显示模式。
-
-| 版本 | 状态 | 说明 |
-|---|---|---|
-| v0.1.1 | 已发布 | 模拟心率悬浮窗和基础样式设置 |
-| v0.1.2 | 已发布 | 补充主题预设说明，优化中文界面和交互说明 |
-| v0.1.3 | 已发布 | 优化桌面使用体验，保存窗口位置和尺寸，增加关闭按钮 |
-| v0.1.4 | 已发布 | 修复窗口状态保存和恢复逻辑 |
-| v0.1.5 | 已发布 | 增加心率数据源模式，支持模拟和手动输入 |
-| v0.1.6 | 已发布 | 增加实验性 BLE 心率数据源，支持标准 BLE 心率读取 |
-| v0.1.7 | 已发布 | 新增纯享心率显示模式，优化透明窗口和显示体验 |
-| v0.2.0 | 计划中 | 进一步完善 BLE 连接稳定性、重连提示和设备兼容性 |
-| v0.3.0 | 计划中 | 优化纯享模式、点击穿透和目标窗口显示体验 |
-| v1.0.0 | 计划中 | 稳定 Windows 发布版本 |
-
----
-
-## 推荐开发环境
-
-如果你想从源码运行或参与开发，建议使用以下环境：
-
-- Windows 10 / Windows 11
-- Node.js 22 LTS
-- Git
-- 支持 BLE 的 Windows 设备
-
----
-
-## 本地运行说明
-
-安装依赖：
+### 1. 安装依赖
 
 ```bash
 npm install
 ```
 
-启动开发模式：
+### 2. 启动开发模式
 
 ```bash
 npm run dev
 ```
 
-如果依赖安装完成并启动成功，HeartDock 会以 Electron 窗口形式运行。
+启动成功后，HeartDock 会以 Electron 窗口形式运行。
+
+如果安装依赖时 Electron 下载失败，请查看：
+
+[开发环境与依赖安装说明](docs/dev-setup.md)
 
 ---
 
@@ -91,21 +70,20 @@ HeartDock 当前支持三种心率数据源：
 |---|---|
 | 模拟心率 | 自动生成模拟 BPM，适合测试界面样式和颜色变化 |
 | 手动输入 | 固定显示用户输入的 BPM，适合调试、演示或临时展示 |
-| BLE 心率设备（实验） | 通过 Web Bluetooth 连接标准 BLE 心率设备并读取实时心率 |
+| BLE 心率设备（实验） | 连接支持标准 BLE Heart Rate Service 的设备并读取实时心率 |
 
-BLE 模式目前优先支持标准蓝牙心率服务：
+BLE 模式优先支持标准蓝牙心率服务：
 
-- Heart Rate Service: `0x180D`
-- Heart Rate Measurement: `0x2A37`
+- Heart Rate Service：`0x180D`
+- Heart Rate Measurement：`0x2A37`
 
-如果设备支持标准 BLE Heart Rate Service，HeartDock 有机会直接读取实时心率。  
 如果设备使用厂商私有协议、需要认证密钥，或者不广播标准心率服务，当前版本可能无法直接读取。
 
 ---
 
 ## 纯享心率显示模式
 
-纯享模式用于正式桌面显示、直播或录屏叠加。
+纯享模式适合正式桌面显示、直播或录屏叠加。
 
 开启后会隐藏设置面板、顶部标识、设置按钮和关闭按钮，只保留：
 
@@ -113,8 +91,11 @@ BLE 模式目前优先支持标准蓝牙心率服务：
 - BPM 数字
 - `bpm` 单位
 
-纯享模式会尽量保持背景透明，只显示心率本体。  
-可以通过双击心率显示区域退出纯享模式。
+纯享模式支持：
+
+- 背景透明
+- 按住心率本体拖动位置
+- 双击心率区域退出纯享模式
 
 ---
 
@@ -122,107 +103,54 @@ BLE 模式目前优先支持标准蓝牙心率服务：
 
 | 快捷键 | 功能 |
 |---|---|
-| Ctrl + Shift + H | 开启 / 关闭点击穿透模式 |
+| `Ctrl + Shift + H` | 开启 / 关闭点击穿透模式 |
 
-如果开启了点击穿透模式，鼠标点击会穿过悬浮窗，无法直接点击悬浮窗界面。  
-可以使用 `Ctrl + Shift + H` 关闭点击穿透模式。
+点击穿透开启后，鼠标会穿过悬浮窗，无法直接点击此窗口。  
+如果误开启点击穿透，可以用 `Ctrl + Shift + H` 关闭。
 
 ---
 
-## Electron 依赖下载问题
+## 文档导航
 
-在中国大陆或网络不稳定环境下，`npm install` 可能会卡在 Electron 依赖安装阶段。
-
-常见错误包括：
-
-```text
-RequestError: read ECONNRESET
-node_modules/electron
-node install.js
-```
-
-这通常不是项目代码问题，而是 Electron 安装时需要额外下载二进制文件，下载过程被中断了。
-
-可以尝试设置 npm 和 Electron 镜像：
-
-```bash
-npm config set registry https://registry.npmmirror.com
-npm config set electron_mirror https://npmmirror.com/mirrors/electron/
-npm config set electron_builder_binaries_mirror https://npmmirror.com/mirrors/electron-builder-binaries/
-```
-
-如果已经装到一半失败，建议关闭残留进程并重新安装：
-
-```bash
-taskkill /F /IM node.exe
-taskkill /F /IM electron.exe
-rmdir /s /q node_modules
-npm install
-```
-
-如果还是卡在 Electron 下载，可以在当前命令行窗口临时设置镜像后再安装：
-
-```bash
-set ELECTRON_MIRROR=https://npmmirror.com/mirrors/electron/
-npm install
-```
-
-如果 `node_modules` 删除失败，通常是文件被 VS Code、资源管理器、杀毒软件或残留进程占用。  
-可以关闭相关程序后重试，必要时重启电脑再执行安装。
+| 文档 | 说明 |
+|---|---|
+| [开发环境与依赖安装说明](docs/dev-setup.md) | Node.js、npm install、Electron 下载失败、镜像配置和常见排错 |
+| [Electron 开发注意事项](docs/electron-notes.md) | 透明窗口、点击穿透、窗口状态保存、安全配置和维护建议 |
+| [悬浮窗限制说明](docs/overlay-limitations.md) | HeartDock 适合哪些窗口场景，以及哪些场景不保证可用 |
+| [开发路线图](docs/roadmap.md) | 当前版本进度和后续计划 |
 
 ---
 
 ## 当前限制
 
-HeartDock 当前优先支持以下场景：
-
-- 桌面悬浮显示
-- 普通窗口上方显示
-- 无边框全屏窗口场景
-- 直播 / 录屏画面叠加
-
-当前仍存在以下限制：
+HeartDock 当前仍处于早期预发布阶段，主要限制包括：
 
 - BLE 心率数据源仍为实验功能
 - 暂不保证所有 BLE 设备都能连接
-- 暂未支持 BLE 自动重连
+- 暂未支持后台自动重连
 - 暂未提供正式 Windows 安装包
+- 设置窗口当前固定默认尺寸，暂不支持可靠缩放
 - 独占全屏程序上方显示不保证可用
 - 透明窗口和点击穿透在不同 Windows 环境下可能存在差异
 
 更多说明见：
 
-[docs/overlay-limitations.md](docs/overlay-limitations.md)
+[悬浮窗限制说明](docs/overlay-limitations.md)
 
 ---
 
 ## 开发路线
 
-当前计划如下：
-
-1. 完成 v0.1.x 起步项目和 GitHub 工作流
-2. 完善桌面悬浮窗基础体验
-3. 增加主题预设和中文设置界面
-4. 增加窗口位置 / 尺寸保存
-5. 增加模拟、手动和 BLE 心率数据源
-6. 增加纯享心率显示模式
-7. 优化透明窗口、点击穿透和显示区域交互
-8. 增强 BLE 连接稳定性和设备兼容性
-9. 提供 Windows 安装包
-10. 增加目标窗口跟随模式
-11. 打包稳定 Windows 发布版本
-
 详细路线见：
 
-[docs/roadmap.md](docs/roadmap.md)
+[开发路线图](docs/roadmap.md)
 
 ---
 
-## License / 许可证
+## 许可证
 
 本项目使用 **GNU Affero General Public License v3.0 only** 开源许可证。
 
-HeartDock 遵循 GNU AGPL v3.0 协议发布。  
 如果你修改、分发本项目，或者将修改后的版本作为网络服务提供给他人使用，需要遵守 AGPL v3.0 的相关条款，并按要求开放对应源码。
 
 详情请查看 [LICENSE](LICENSE)。

--- a/docs/overlay-limitations.md
+++ b/docs/overlay-limitations.md
@@ -1,25 +1,102 @@
-# Overlay limitations
+# 悬浮窗限制说明
 
-HeartDock v0.1 uses a normal transparent always-on-top Electron window.
+HeartDock 使用 Electron 的透明置顶窗口来实现桌面心率悬浮显示。
 
-This is suitable for:
+这种方式适合大多数普通桌面场景，但不应该承诺可以覆盖所有程序，尤其是不应该承诺一定能覆盖独占全屏游戏或受保护渲染的窗口。
 
-- desktop overlay
-- normal application windows
-- maximized windows
-- many borderless fullscreen windows
+---
 
-It may not work reliably over:
+## 适合的场景
 
-- exclusive fullscreen games
-- applications that use protected rendering
-- apps with anti-cheat or anti-overlay systems
-- system-level secure desktops
+HeartDock 当前主要适合以下场景：
 
-## Project policy
+- Windows 桌面
+- 普通应用窗口
+- 最大化窗口
+- 多数无边框全屏窗口
+- 直播画面叠加
+- 录屏画面叠加
+- 日常桌面心率观察
 
-HeartDock should not promise universal fullscreen overlay support.
+例如：
 
-Recommended wording:
+- 浏览器窗口
+- 编辑器窗口
+- 视频播放器普通窗口
+- 直播软件画面
+- 无边框窗口化运行的程序
 
-> HeartDock focuses on desktop, normal-window, and borderless-fullscreen overlay scenarios. Exclusive fullscreen support is experimental and not guaranteed.
+---
+
+## 不保证可用的场景
+
+以下场景可能无法稳定显示在最上层：
+
+- 独占全屏游戏
+- 使用受保护渲染的应用
+- 带有反作弊或反覆盖层机制的游戏
+- 系统级安全桌面
+- 权限级别高于 HeartDock 的管理员窗口
+- 特殊显卡驱动或硬件加速环境
+- 某些屏幕录制、投屏或虚拟桌面环境
+
+这些限制主要来自 Windows、Electron、显卡驱动和目标应用本身，并不完全由 HeartDock 控制。
+
+---
+
+## 当前项目策略
+
+HeartDock 当前不承诺“万能覆盖所有窗口”。
+
+推荐表述是：
+
+> HeartDock 主要面向桌面、普通窗口和无边框全屏窗口的心率悬浮显示场景。独占全屏支持属于实验性能力，不保证在所有应用中可用。
+
+---
+
+## 透明窗口相关限制
+
+为了实现纯享心率显示模式，HeartDock 使用透明无边框窗口。
+
+这种方式带来了一些取舍：
+
+- 透明窗口下原生缩放不够稳定
+- 点击穿透需要动态切换
+- 打开开发者工具时透明效果可能异常
+- 不同 Windows 版本、DPI、显卡驱动下表现可能不同
+
+因此当前阶段采用以下策略：
+
+- 设置窗口固定默认尺寸
+- 只保存窗口位置
+- 不保存异常窗口宽高
+- 纯享模式拖动只改变窗口位置
+- 点击穿透通过快捷键和程序逻辑动态切换
+
+更多 Electron 相关说明见：
+
+[Electron 开发注意事项](./electron-notes.md)
+
+---
+
+## 使用建议
+
+如果需要更稳定的悬浮显示，建议：
+
+- 优先使用普通窗口或无边框窗口化模式
+- 避免使用独占全屏
+- 如果悬浮窗没有显示在目标程序上方，尝试切换目标程序的显示模式
+- 如果开启点击穿透后无法点击窗口，使用 `Ctrl + Shift + H` 关闭点击穿透
+- 如果窗口位置异常，可以删除本地窗口状态文件或重置配置
+
+---
+
+## 后续可能优化
+
+后续可以继续研究：
+
+- 目标窗口跟随模式
+- 更精细的点击穿透区域控制
+- 自定义缩放手柄
+- 多显示器和高 DPI 场景优化
+- 更完整的用户排错说明

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,38 +1,167 @@
-# Roadmap
+# 开发路线图
 
-## v0.1.0 — GitHub starter and mock overlay
+本文记录 HeartDock 的阶段目标、当前进度和后续计划。
 
-- [x] Project structure
-- [x] Transparent overlay window
-- [x] Mock heart rate source
-- [x] Basic style settings
-- [x] Documentation
-- [x] GitHub workflow
+HeartDock 当前处于早期预发布阶段。当前重点是先把 Windows 桌面心率悬浮窗、标准 BLE 心率读取、纯享显示模式和基础开发流程打磨稳定，再逐步考虑安装包、目标窗口跟随和更完整的用户体验。
 
-## v0.2.0 — Standard BLE heart rate support
+---
 
-- [ ] Scan BLE devices
-- [ ] Connect to standard heart rate devices
-- [ ] Subscribe to heart rate measurement values
-- [ ] Handle disconnect and reconnect
+## 当前状态
 
-## v0.3.0 — Mi Band research
+当前最新版本：**v0.1.9**
 
-- [ ] Document supported Mi Band models
-- [ ] Research authentication key workflow
-- [ ] Add experimental Mi Band adapter
-- [ ] Add clear setup guide
+当前已经完成：
 
-## v0.4.0 — Target-window follow mode
+- GitHub 项目基础结构
+- Electron 桌面悬浮窗
+- 模拟心率数据源
+- 手动输入心率数据源
+- 实验性标准 BLE 心率数据源
+- BLE 心率实时显示
+- BLE 空状态显示
+- BLE 断线后快速重连入口
+- 中文设置界面
+- 主题预设
+- 字体大小和刷新间隔设置
+- 点击穿透
+- 纯享心率显示模式
+- 纯享模式下拖动心率位置
+- 窗口位置保存
+- README 和 docs 文档整理
+- GitHub Issue / PR / Release 基础流程
 
-- [ ] List visible windows
-- [ ] Select target window
-- [ ] Follow target window position
-- [ ] Auto-hide when target window is minimized
+---
 
-## v1.0.0 — Stable release
+## v0.1.x — 起步版本和核心体验
 
-- [ ] Windows installer
-- [ ] Theme presets
-- [ ] Full user guide
-- [ ] Release notes
+状态：进行中，已发布到 v0.1.9。
+
+目标是完成 HeartDock 的最小可用版本，让它能作为一个桌面心率悬浮窗正常运行。
+
+已完成：
+
+- [x] 项目结构
+- [x] 透明悬浮窗
+- [x] 始终置顶
+- [x] 模拟心率
+- [x] 手动输入心率
+- [x] 主题预设
+- [x] 字体大小设置
+- [x] 刷新间隔设置
+- [x] 点击穿透
+- [x] 窗口位置保存
+- [x] 纯享心率显示模式
+- [x] 纯享模式拖动位置
+- [x] 标准 BLE 心率服务读取
+- [x] BLE 未连接时显示 `-- bpm`
+- [x] BLE 断线后快速重连入口
+- [x] 开发文档和 Electron 注意事项文档
+
+待继续优化：
+
+- [ ] 继续观察 BLE 连接稳定性
+- [ ] 优化 BLE 失败提示和边界状态
+- [ ] 根据实际使用反馈微调纯享模式交互
+- [ ] 整理正式打包前的配置
+
+---
+
+## v0.2.0 — 标准 BLE 心率支持增强
+
+目标是让标准 BLE Heart Rate Service 的使用体验更稳定。
+
+计划内容：
+
+- [x] 扫描支持 Heart Rate Service 的 BLE 设备
+- [x] 连接标准 BLE 心率设备
+- [x] 订阅 Heart Rate Measurement 通知
+- [x] 显示实时心率
+- [x] 处理断开状态
+- [x] 支持同一运行会话内快速重连上次设备
+- [ ] 优化断线提示和重连失败提示
+- [ ] 研究是否需要更明确的设备兼容性说明
+- [ ] 补充 BLE 使用说明文档
+- [ ] 评估后台自动重连是否值得实现
+
+说明：
+
+当前 BLE 功能以标准 BLE Heart Rate Service 为主，不处理厂商私有协议、认证密钥或专有命令。
+
+---
+
+## v0.3.0 — 显示体验和窗口交互增强
+
+目标是继续优化悬浮显示、纯享模式和窗口交互体验。
+
+计划内容：
+
+- [ ] 研究设置窗口自定义缩放手柄
+- [ ] 优化透明窗口在不同 DPI 下的显示效果
+- [ ] 优化纯享模式的鼠标命中区域
+- [ ] 增加更多主题预设
+- [ ] 增加颜色区间自定义能力
+- [ ] 增加配置重置和导入导出能力
+- [ ] 补充完整用户使用说明
+
+---
+
+## v0.4.0 — 目标窗口跟随模式
+
+目标是让 HeartDock 可以跟随指定窗口位置，适合直播、录屏或固定叠加场景。
+
+计划内容：
+
+- [ ] 列出可见窗口
+- [ ] 选择目标窗口
+- [ ] 跟随目标窗口移动
+- [ ] 目标窗口最小化时自动隐藏
+- [ ] 目标窗口关闭后提示用户重新选择
+- [ ] 研究不同 Windows 环境下的兼容性
+
+---
+
+## v0.5.0 — 打包和发布体验
+
+目标是让普通用户不需要 Node.js/npm，也能直接安装和使用 HeartDock。
+
+计划内容：
+
+- [ ] 配置 electron-builder
+- [ ] 生成 Windows 安装包
+- [ ] 生成便携版或安装版方案评估
+- [ ] 优化安装包体积
+- [ ] 在 GitHub Release 上传安装包
+- [ ] 补充普通用户安装说明
+- [ ] 补充开发者从源码运行说明和普通用户安装说明的区别
+
+---
+
+## v1.0.0 — 稳定 Windows 发布版
+
+目标是发布一个相对稳定的 Windows 桌面心率悬浮窗版本。
+
+计划内容：
+
+- [ ] 标准 BLE 心率读取稳定
+- [ ] 常用设备兼容性说明清晰
+- [ ] 纯享模式稳定
+- [ ] 点击穿透和窗口状态稳定
+- [ ] Windows 安装包可用
+- [ ] 用户说明文档完整
+- [ ] 已知限制说明清楚
+- [ ] Release notes 完整
+
+---
+
+## 暂不优先处理的方向
+
+以下内容暂时不作为近期重点：
+
+- 小米手环私有协议适配
+- 厂商私有认证密钥流程
+- 跨平台 macOS / Linux 支持
+- 自动更新
+- 云端同步
+- 用户账号系统
+
+这些方向不是完全放弃，而是当前阶段优先级低于标准 BLE、Windows 悬浮窗体验和安装包发布。


### PR DESCRIPTION
## 本次修改

- 精简 README，减少重复的详细说明
- 在 README 中增加文档导航入口
- 将开发环境和依赖安装说明指向 `docs/dev-setup.md`
- 将 Electron 透明窗口、点击穿透和窗口状态说明指向 `docs/electron-notes.md`
- 将悬浮窗适用场景和限制说明整理到 `docs/overlay-limitations.md`
- 将 `docs/roadmap.md` 改为中文并更新到 v0.1.9 当前进度
- 保持项目说明文档以中文为主

## 测试

- 文档修改，无需运行功能测试
- 已检查文档链接路径

## 关联 Issue

Closes #31