### PR TITLE
feat: 增加设置窗口自定义缩放手柄

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -31,6 +31,11 @@ const DEFAULT_WINDOW_STATE: WindowState = {
   height: 560
 }
 
+const MAX_WINDOW_STATE: WindowState = {
+  width: 1100,
+  height: 720
+}
+
 function getWindowStatePath(): string {
   return join(app.getPath('userData'), 'window-state.json')
 }
@@ -45,18 +50,26 @@ function clampNumber(value: unknown, min: number, max: number, fallback: number)
 
 function getNormalizedWindowSize(state: WindowState): Pick<WindowState, 'width' | 'height'> {
   const primaryWorkArea = screen.getPrimaryDisplay().workArea
+  const maxWindowWidth = Math.min(
+    MAX_WINDOW_STATE.width,
+    Math.max(MIN_WINDOW_STATE.width, primaryWorkArea.width)
+  )
+  const maxWindowHeight = Math.min(
+    MAX_WINDOW_STATE.height,
+    Math.max(MIN_WINDOW_STATE.height, primaryWorkArea.height)
+  )
 
   return {
     width: clampNumber(
       state.width,
       MIN_WINDOW_STATE.width,
-      Math.max(MIN_WINDOW_STATE.width, primaryWorkArea.width),
+      maxWindowWidth,
       DEFAULT_WINDOW_STATE.width
     ),
     height: clampNumber(
       state.height,
       MIN_WINDOW_STATE.height,
-      Math.max(MIN_WINDOW_STATE.height, primaryWorkArea.height),
+      maxWindowHeight,
       DEFAULT_WINDOW_STATE.height
     )
   }
@@ -270,11 +283,21 @@ function registerIpcHandlers(): void {
         return false
       }
 
+      const primaryWorkArea = screen.getPrimaryDisplay().workArea
+      const maxWindowWidth = Math.min(
+        MAX_WINDOW_STATE.width,
+        Math.max(MIN_WINDOW_STATE.width, primaryWorkArea.width)
+      )
+      const maxWindowHeight = Math.min(
+        MAX_WINDOW_STATE.height,
+        Math.max(MIN_WINDOW_STATE.height, primaryWorkArea.height)
+      )
+
       const nextBounds = {
         x: Math.round(bounds.x),
         y: Math.round(bounds.y),
-        width: Math.max(Math.round(bounds.width), MIN_WINDOW_STATE.width),
-        height: Math.max(Math.round(bounds.height), MIN_WINDOW_STATE.height)
+        width: clampNumber(bounds.width, MIN_WINDOW_STATE.width, maxWindowWidth, DEFAULT_WINDOW_STATE.width),
+        height: clampNumber(bounds.height, MIN_WINDOW_STATE.height, maxWindowHeight, DEFAULT_WINDOW_STATE.height)
       }
 
       overlayWindow.setBounds(nextBounds, false)
@@ -308,6 +331,8 @@ function createOverlayWindow(): void {
     y: windowState.y,
     minWidth: MIN_WINDOW_STATE.width,
     minHeight: MIN_WINDOW_STATE.height,
+    maxWidth: MAX_WINDOW_STATE.width,
+    maxHeight: MAX_WINDOW_STATE.height,
     frame: false,
     transparent: true,
     backgroundColor: '#00000000',

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -150,6 +150,12 @@ function App() {
   })
 
   const pureDragMovedRef = useRef(false)
+  const windowResizeStateRef = useRef({
+    isResizing: false,
+    startScreenX: 0,
+    startScreenY: 0,
+    startBounds: null as HeartDockWindowBounds | null
+  })
 
   const [bpm, setBpm] = useState(() => normalizeBpm(initialConfigRef.current?.manualBpm ?? 78))
   const [config, setConfig] = useState<HeartDockConfig>(() => initialConfigRef.current ?? loadConfig())
@@ -375,6 +381,58 @@ function App() {
       window.setTimeout(() => {
         pureDragMovedRef.current = false
       }, 180)
+    }
+
+    window.addEventListener('mousemove', handleMouseMove)
+    window.addEventListener('mouseup', handleMouseUp)
+  }
+
+  const handleWindowResizeMouseDown = async (
+    event: ReactMouseEvent<HTMLButtonElement>
+  ): Promise<void> => {
+    if (event.button !== 0 || isPureDisplay) {
+      return
+    }
+
+    event.preventDefault()
+    event.stopPropagation()
+
+    const bounds = await window.heartdock.getWindowBounds()
+
+    if (!bounds) {
+      return
+    }
+
+    windowResizeStateRef.current = {
+      isResizing: true,
+      startScreenX: event.screenX,
+      startScreenY: event.screenY,
+      startBounds: bounds
+    }
+
+    const handleMouseMove = (moveEvent: MouseEvent): void => {
+      const resizeState = windowResizeStateRef.current
+
+      if (!resizeState.isResizing || !resizeState.startBounds) {
+        return
+      }
+
+      const deltaX = moveEvent.screenX - resizeState.startScreenX
+      const deltaY = moveEvent.screenY - resizeState.startScreenY
+
+      const nextBounds: HeartDockWindowBounds = {
+        ...resizeState.startBounds,
+        width: resizeState.startBounds.width + deltaX,
+        height: resizeState.startBounds.height + deltaY
+      }
+
+      void window.heartdock.setWindowBounds(nextBounds)
+    }
+
+    const handleMouseUp = (): void => {
+      windowResizeStateRef.current.isResizing = false
+      window.removeEventListener('mousemove', handleMouseMove)
+      window.removeEventListener('mouseup', handleMouseUp)
     }
 
     window.addEventListener('mousemove', handleMouseMove)
@@ -793,15 +851,6 @@ function App() {
 
             <div className="window-actions no-drag">
               <button
-                className="icon-button"
-                type="button"
-                title="显示或隐藏设置"
-                onClick={() => updateConfig('showSettings', !config.showSettings)}
-              >
-                ⚙
-              </button>
-
-              <button
                 className="icon-button close-button"
                 type="button"
                 title="关闭 HeartDock"
@@ -957,7 +1006,7 @@ function App() {
               </div>
 
               <p className="hint">
-                纯享模式下可以按住心率本体拖动位置，双击心率区域退出纯享模式。
+                纯享模式下可以按住心率本体拖动位置，双击心率区域退出纯享模式。设置页面右下角的斜纹手柄可以拖动调整窗口大小。
               </p>
 
               <label>
@@ -988,7 +1037,7 @@ function App() {
               </label>
 
               <label>
-                刷新间隔 ms
+                模拟心率刷新间隔 ms
                 <input
                   type="number"
                   min="250"
@@ -1002,16 +1051,16 @@ function App() {
               </label>
 
               <p className="hint">
-                背景透明度会在隐藏设置面板后生效。设置面板打开时会使用不透明背景，避免桌面内容透出影响可读性。
+                刷新间隔只影响模拟心率模式；手动输入和 BLE 实时心率不按这个间隔刷新。
               </p>
 
               <div className="click-through-status">
-                <span>点击穿透</span>
+                <span>鼠标穿透交互</span>
                 <strong>{config.clickThrough ? '已开启' : '已关闭'}</strong>
               </div>
 
               <p className="hint">
-                点击穿透开启后，鼠标会穿过悬浮窗，无法直接点击此窗口。请使用 Ctrl + Shift + H 开启或关闭点击穿透。
+                开启后，鼠标点击会穿过 HeartDock，直接操作下方窗口；需要再次操作 HeartDock 时，请按 Ctrl + Shift + H 关闭。
               </p>
 
               <button className="reset-button" type="button" onClick={handleResetConfig}>
@@ -1019,6 +1068,15 @@ function App() {
               </button>
             </div>
           )}
+          <button
+            className="resize-handle no-drag"
+            type="button"
+            aria-label="拖动调整窗口大小"
+            title="拖动调整窗口大小"
+            onMouseDown={(event) => void handleWindowResizeMouseDown(event)}
+          >
+            <span className="resize-handle-label">调整大小</span>
+          </button>
         </section>
       )}
     </main>

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -206,9 +206,9 @@ select {
 
 .settings-panel {
   display: grid;
-  max-height: calc(100vh - 158px);
+  max-height: calc(100vh - 168px);
   gap: 10px;
-  padding: 14px;
+  padding: 14px 14px 42px;
   overflow-y: auto;
   overscroll-behavior: contain;
   border: 1px solid rgba(148, 163, 184, 0.14);
@@ -240,6 +240,12 @@ select {
 .settings-panel::-webkit-scrollbar-thumb:hover {
   background: rgba(203, 213, 225, 0.72);
   background-clip: content-box;
+}
+
+.settings-panel::after {
+  content: "";
+  display: block;
+  height: 6px;
 }
 
 .settings-panel label {
@@ -486,6 +492,97 @@ select {
     inset 0 1px 0 rgba(255, 255, 255, 0.16);
 }
 
+
+.resize-handle {
+  position: absolute;
+  right: 11px;
+  bottom: 11px;
+  z-index: 8;
+  width: 26px;
+  height: 26px;
+  border: 0;
+  border-radius: 9px;
+  background:
+    linear-gradient(135deg, transparent 0 50%, rgba(56, 189, 248, 0.18) 50%),
+    rgba(15, 23, 42, 0.42);
+  cursor: nwse-resize;
+  opacity: 0.9;
+  box-shadow:
+    inset 0 0 0 1px rgba(125, 211, 252, 0.28),
+    0 0 14px rgba(56, 189, 248, 0.12);
+  transition:
+    opacity 0.16s ease,
+    background 0.16s ease,
+    box-shadow 0.16s ease,
+    transform 0.16s ease;
+}
+
+.resize-handle::before,
+.resize-handle::after {
+  content: "";
+  position: absolute;
+  right: 6px;
+  bottom: 6px;
+  width: 12px;
+  height: 12px;
+  pointer-events: none;
+  background:
+    linear-gradient(135deg, transparent 0 56%, rgba(224, 242, 254, 0.96) 56% 64%, transparent 64%),
+    linear-gradient(135deg, transparent 0 76%, rgba(125, 211, 252, 0.86) 76% 84%, transparent 84%);
+}
+
+.resize-handle::after {
+  right: 8px;
+  bottom: 8px;
+  width: 8px;
+  height: 8px;
+  opacity: 0.9;
+}
+
+.resize-handle-label {
+  position: absolute;
+  right: 29px;
+  bottom: 0;
+  width: max-content;
+  padding: 4px 7px;
+  border: 1px solid rgba(125, 211, 252, 0.28);
+  border-radius: 999px;
+  color: rgba(224, 242, 254, 0.92);
+  background: rgba(15, 23, 42, 0.94);
+  font-size: 11px;
+  font-weight: 700;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateX(4px);
+  transition:
+    opacity 0.16s ease,
+    transform 0.16s ease;
+}
+
+.resize-handle:hover {
+  opacity: 1;
+  background:
+    linear-gradient(135deg, transparent 0 48%, rgba(56, 189, 248, 0.28) 48%),
+    rgba(15, 23, 42, 0.68);
+  box-shadow:
+    inset 0 0 0 1px rgba(186, 230, 253, 0.56),
+    0 0 0 3px rgba(56, 189, 248, 0.12),
+    0 0 20px rgba(56, 189, 248, 0.24);
+}
+
+.resize-handle:hover .resize-handle-label {
+  opacity: 1;
+  transform: translateX(0);
+}
+
+.resize-handle:active {
+  transform: scale(0.94);
+  box-shadow:
+    inset 0 0 0 1px rgba(186, 230, 253, 0.7),
+    0 0 0 4px rgba(56, 189, 248, 0.16),
+    inset 0 2px 8px rgba(0, 0, 0, 0.28);
+}
+
 .source-panel {
   display: grid;
   gap: 8px;
@@ -556,6 +653,7 @@ select {
 
 .reset-button {
   margin-top: 4px;
+  margin-bottom: 8px;
 }
 
 .click-through-status,


### PR DESCRIPTION
## 本次修改

- 在设置窗口右下角增加自定义缩放手柄
- 拖动手柄时通过现有 `setWindowBounds` IPC 调整窗口大小
- 增加设置窗口最大尺寸限制，避免窗口被拉得过大
- 复用主进程最小窗口尺寸限制
- 缩放后的窗口大小会随窗口状态一起保存
- 优化右下角缩放手柄样式和悬停提示
- 删除右上角设置显示/隐藏齿轮按钮，统一通过纯享模式进入正式展示状态
- 将刷新间隔文案调整为“模拟心率刷新间隔”，避免误解为 BLE 心率刷新频率
- 将点击穿透文案调整为“鼠标穿透交互”，降低理解成本
- 保持纯享模式透明显示和拖动位置逻辑不变
- 不依赖 Electron 透明窗口的系统边界缩放

## 测试

- 已测试设置页面可以通过右下角手柄缩放
- 已测试窗口不会缩小到最小尺寸以下
- 已测试窗口不会被拉到过大尺寸
- 已测试放大窗口后底部不会出现大面积无意义空白
- 已测试重置显示设置按钮完整显示
- 已测试关闭后重新打开可以恢复窗口大小
- 已测试纯享模式仍保持透明
- 已测试纯享模式仍可拖动心率位置
- 已测试双击纯享心率可退出纯享模式
- 已测试点击穿透快捷键正常
- 已测试 BLE 实时心率显示正常
- 已运行 npm run typecheck

## 关联 Issue

Closes #33