### PR TITLE
feat: 支持心率显示样式自定义

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -32,8 +32,8 @@ const DEFAULT_WINDOW_STATE: WindowState = {
 }
 
 const MAX_WINDOW_STATE: WindowState = {
-  width: 1100,
-  height: 720
+  width: 1180,
+  height: 900
 }
 
 function getWindowStatePath(): string {

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -9,20 +9,58 @@ import {
 } from 'react'
 
 import {
+  DisplayGlowLevel,
   HeartDockConfig,
+  HeartRateColorMode,
   HeartRateSourceMode,
-  ThemePresetId,
-  applyThemePreset,
   createDefaultConfig,
   loadConfig,
   normalizeBpm,
+  normalizeColor,
+  normalizeDisplayText,
   normalizeRefreshIntervalMs,
-  saveConfig,
-  themePresets
+  saveConfig
 } from './config'
 import { MockHeartRateSource } from './core/MockHeartRateSource'
 
 type BleConnectionStatus = 'idle' | 'connecting' | 'connected' | 'failed'
+
+const colorPresetOptions = [
+  '#4ade80',
+  '#22c55e',
+  '#38bdf8',
+  '#60a5fa',
+  '#a78bfa',
+  '#facc15',
+  '#fb923c',
+  '#fb7185',
+  '#ef4444',
+  '#f8fafc'
+]
+
+interface SelectOption<T extends string> {
+  value: T
+  label: string
+  description?: string
+}
+
+const sourceModeOptions: Array<SelectOption<HeartRateSourceMode>> = [
+  { value: 'mock', label: '模拟心率', description: '自动生成心率，适合测试样式。' },
+  { value: 'manual', label: '手动输入', description: '固定显示指定 BPM。' },
+  { value: 'ble', label: 'BLE 心率设备（实验）', description: '读取标准 BLE 心率服务。' }
+]
+
+const colorModeOptions: Array<SelectOption<HeartRateColorMode>> = [
+  { value: 'range', label: '跟随心率区间', description: '不同心率区间显示不同颜色。' },
+  { value: 'fixed', label: '固定颜色', description: '始终使用同一种颜色。' }
+]
+
+const glowLevelOptions: Array<SelectOption<DisplayGlowLevel>> = [
+  { value: 'off', label: '关闭', description: '不显示发光效果。' },
+  { value: 'soft', label: '弱', description: '轻微发光。' },
+  { value: 'medium', label: '中', description: '默认发光强度。' },
+  { value: 'strong', label: '强', description: '更醒目的发光效果。' }
+]
 
 interface BleCharacteristic {
   value?: DataView
@@ -61,20 +99,24 @@ interface NavigatorWithBluetooth extends Navigator {
 }
 
 function getColorForBpm(bpm: number, config: HeartDockConfig): string {
+  if (config.colorMode === 'fixed') {
+    return config.fixedColor
+  }
+
   const rule = config.colorRules.find((item) => bpm >= item.min && bpm <= item.max)
   return rule?.color ?? '#ffffff'
 }
 
-function getSourceLabel(sourceMode: HeartRateSourceMode): string {
-  if (sourceMode === 'manual') {
-    return '手动'
+function clampColorRuleValue(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 30
   }
 
-  if (sourceMode === 'ble') {
-    return 'BLE'
-  }
+  return Math.min(Math.max(Math.round(value), 30), 240)
+}
 
-  return '模拟'
+function clampNumber(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max)
 }
 
 function parseHeartRateMeasurement(value: DataView): number | null {
@@ -172,6 +214,10 @@ function App() {
     '尚未连接 BLE 心率设备。请先开启 Windows 蓝牙，并确保心率设备正在广播标准心率服务。连接前心率将显示为 -- bpm。'
   )
 
+  const [openColorRuleIndexes, setOpenColorRuleIndexes] = useState<number[]>([])
+
+  const [openSelectId, setOpenSelectId] = useState<string | null>(null)
+
   const shouldShowBlePlaceholder =
     config.heartRateSourceMode === 'ble' && bleStatus !== 'connected'
 
@@ -181,11 +227,8 @@ function App() {
     () => (shouldShowBlePlaceholder ? '#94a3b8' : getColorForBpm(bpm, config)),
     [bpm, config, shouldShowBlePlaceholder]
   )
-  const currentTheme = useMemo(
-    () => themePresets.find((theme) => theme.id === config.themePresetId) ?? themePresets[0],
-    [config.themePresetId]
-  )
   const isPureDisplay = config.pureDisplay
+  const displayGlowClass = `glow-${config.glowLevel}`
 
   useEffect(() => {
     sourceModeRef.current = config.heartRateSourceMode
@@ -289,9 +332,279 @@ function App() {
     setConfig((current) => ({ ...current, [key]: value }))
   }
 
-  const handleThemeChange = (themeId: ThemePresetId): void => {
-    setConfig((current) => applyThemePreset(current, themeId))
+  const handlePrefixTextChange = (value: string): void => {
+    updateConfig('prefixText', normalizeDisplayText(value, '', 8))
   }
+
+  const handleUnitTextChange = (value: string): void => {
+    updateConfig('unitText', normalizeDisplayText(value, '', 8))
+  }
+
+  const handleFixedColorChange = (value: string): void => {
+    updateConfig('fixedColor', normalizeColor(value, config.fixedColor))
+  }
+
+  const handleColorRuleColorChange = (index: number, color: string): void => {
+    setConfig((current) => ({
+      ...current,
+      colorRules: current.colorRules.map((rule, ruleIndex) =>
+        ruleIndex === index ? { ...rule, color: normalizeColor(color, rule.color) } : rule
+      )
+    }))
+  }
+
+  const handleColorRuleToggle = (index: number, isOpen: boolean): void => {
+    setOpenColorRuleIndexes((current) => {
+      if (isOpen) {
+        return current.includes(index) ? current : [...current, index]
+      }
+
+      return current.filter((item) => item !== index)
+    })
+  }
+
+  const updateColorRuleRange = (
+    index: number,
+    key: 'min' | 'max',
+    rawValue: number
+  ): void => {
+    if (!Number.isFinite(rawValue)) {
+      return
+    }
+
+    setConfig((current) => {
+      const nextRules = current.colorRules.map((rule) => ({ ...rule }))
+      const currentRule = nextRules[index]
+
+      if (!currentRule) {
+        return current
+      }
+
+      const nextValue = clampColorRuleValue(rawValue)
+
+      if (key === 'max') {
+        const remainingRuleCount = nextRules.length - index - 1
+        const maxLimit = 240 - remainingRuleCount
+
+        currentRule.max = clampNumber(nextValue, currentRule.min, maxLimit)
+
+        for (let ruleIndex = index + 1; ruleIndex < nextRules.length; ruleIndex++) {
+          const previousRule = nextRules[ruleIndex - 1]
+          const rule = nextRules[ruleIndex]
+          const remainingAfterThisRule = nextRules.length - ruleIndex - 1
+          const maxForThisRule = 240 - remainingAfterThisRule
+
+          rule.min = clampNumber(previousRule.max + 1, 30, maxForThisRule)
+          rule.max = clampNumber(Math.max(rule.max, rule.min), rule.min, maxForThisRule)
+        }
+      } else {
+        const previousRuleCount = index
+        const minLimit = 30 + previousRuleCount
+
+        currentRule.min = clampNumber(nextValue, minLimit, currentRule.max)
+
+        for (let ruleIndex = index - 1; ruleIndex >= 0; ruleIndex--) {
+          const nextRule = nextRules[ruleIndex + 1]
+          const rule = nextRules[ruleIndex]
+          const minForThisRule = 30 + ruleIndex
+
+          rule.max = clampNumber(nextRule.min - 1, minForThisRule, 240)
+          rule.min = clampNumber(Math.min(rule.min, rule.max), minForThisRule, rule.max)
+        }
+      }
+
+      return {
+        ...current,
+        colorRules: nextRules
+      }
+    })
+  }
+
+  const handleColorRuleRangeChange = (
+    index: number,
+    key: 'min' | 'max',
+    value: string
+  ): void => {
+    if (!value.trim()) {
+      return
+    }
+
+    updateColorRuleRange(index, key, Number(value))
+  }
+
+  const handleColorRuleRangeStep = (index: number, key: 'min' | 'max', delta: number): void => {
+    const rule = config.colorRules[index]
+
+    if (!rule) {
+      return
+    }
+
+    const currentValue = key === 'min' ? rule.min : rule.max
+    updateColorRuleRange(index, key, currentValue + delta)
+  }
+
+  const renderCustomSelect = <T extends string>(
+    id: string,
+    value: T,
+    options: Array<SelectOption<T>>,
+    onChange: (value: T) => void,
+    ariaLabel: string
+  ) => {
+    const selectedOption = options.find((option) => option.value === value) ?? options[0]
+    const isOpen = openSelectId === id
+
+    return (
+      <div className={`custom-select ${isOpen ? 'is-open' : ''}`} onClick={(event) => event.stopPropagation()}>
+        <button
+          className="custom-select-trigger"
+          type="button"
+          aria-label={ariaLabel}
+          aria-expanded={isOpen}
+          onClick={(event) => {
+            event.preventDefault()
+            event.stopPropagation()
+            setOpenSelectId((current) => (current === id ? null : id))
+          }}
+        >
+          <span className="custom-select-value">{selectedOption.label}</span>
+          <span className="custom-select-chevron" aria-hidden="true">
+            ▾
+          </span>
+        </button>
+
+        {isOpen && (
+          <div className="custom-select-menu" role="listbox">
+            {options.map((option) => (
+              <button
+                key={option.value}
+                className={`custom-select-option ${option.value === value ? 'is-selected' : ''}`}
+                type="button"
+                role="option"
+                aria-selected={option.value === value}
+                onClick={(event) => {
+                  event.preventDefault()
+                  event.stopPropagation()
+                  onChange(option.value)
+                  setOpenSelectId(null)
+                }}
+              >
+                <span>{option.label}</span>
+                {option.description && <small>{option.description}</small>}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+    )
+  }
+
+  const renderRangeControl = (
+    value: number,
+    onInputChange: (value: string) => void,
+    onStep: (delta: number) => void,
+    ariaLabel: string
+  ) => (
+    <div className="range-field" aria-label={ariaLabel} onClick={(event) => event.stopPropagation()}>
+      <input
+        className="range-value-input"
+        type="text"
+        inputMode="numeric"
+        value={value}
+        onPointerDown={(event) => event.stopPropagation()}
+        onMouseDown={(event) => event.stopPropagation()}
+        onClick={(event) => event.stopPropagation()}
+        onChange={(event) => {
+          const nextValue = event.target.value.trim()
+
+          if (/^\d{0,3}$/.test(nextValue)) {
+            onInputChange(nextValue)
+          }
+        }}
+        onBlur={(event) => onInputChange(event.currentTarget.value)}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter') {
+            event.currentTarget.blur()
+          }
+        }}
+      />
+
+      <div className="range-action-row">
+        <button
+          className="range-action-button"
+          type="button"
+          aria-label="减少 1"
+          onPointerDown={(event) => event.stopPropagation()}
+          onMouseDown={(event) => event.stopPropagation()}
+          onClick={(event) => {
+            event.preventDefault()
+            event.stopPropagation()
+            onStep(-1)
+          }}
+        >
+          −1
+        </button>
+
+        <button
+          className="range-action-button"
+          type="button"
+          aria-label="增加 1"
+          onPointerDown={(event) => event.stopPropagation()}
+          onMouseDown={(event) => event.stopPropagation()}
+          onClick={(event) => {
+            event.preventDefault()
+            event.stopPropagation()
+            onStep(1)
+          }}
+        >
+          +1
+        </button>
+      </div>
+    </div>
+  )
+
+  const renderColorControl = (
+    color: string,
+    onChange: (color: string) => void,
+    ariaLabel: string
+  ) => (
+    <div className="custom-color-control" aria-label={ariaLabel} onClick={(event) => event.stopPropagation()}>
+      <div className="color-preview-card">
+        <span className="color-preview" style={{ backgroundColor: color }} />
+        <div className="hex-input-wrap">
+          <input
+            key={color}
+            className="hex-color-input"
+            type="text"
+            defaultValue={color}
+            maxLength={7}
+            spellCheck={false}
+            onBlur={(event) => onChange(normalizeColor(event.currentTarget.value.trim(), color))}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter') {
+                event.currentTarget.blur()
+              }
+            }}
+          />
+          <small>可手动输入 RGB 16 进制颜色码，例如 #4ade80。</small>
+        </div>
+      </div>
+
+      <div className="color-swatch-grid" aria-label="预设颜色">
+        {colorPresetOptions.map((presetColor) => (
+          <button
+            key={presetColor}
+            className={`color-swatch-button ${presetColor.toLowerCase() === color.toLowerCase() ? 'is-active' : ''}`}
+            type="button"
+            aria-label={`选择颜色 ${presetColor}`}
+            title={presetColor}
+            style={{ backgroundColor: presetColor }}
+            onClick={() => onChange(presetColor)}
+          />
+        ))}
+      </div>
+    </div>
+  )
+
 
   const handleTogglePureDisplay = async (): Promise<void> => {
     if (!config.pureDisplay) {
@@ -817,7 +1130,7 @@ function App() {
         <section className="pure-display-view no-drag">
           <div
             ref={pureHeartRef}
-            className="pure-heart-row"
+            className={`pure-heart-row heart-display-row ${displayGlowClass}`}
             title="按住拖动位置，双击退出纯享模式"
             onMouseDown={handlePureDisplayMouseDown}
             onDoubleClick={handlePureDisplayDoubleClick}
@@ -828,13 +1141,15 @@ function App() {
               }
             }}
           >
-            <span className="heart pure-heart" style={{ color: bpmColor }}>
-              ♥
-            </span>
+            {config.prefixText && (
+              <span className="heart prefix-text pure-heart" style={{ color: bpmColor }}>
+                {config.prefixText}
+              </span>
+            )}
             <span className="bpm pure-bpm" style={{ color: bpmColor, fontSize: config.fontSize }}>
               {displayBpm}
             </span>
-            <span className="unit pure-unit">bpm</span>
+            {config.unitText && <span className="unit pure-unit">{config.unitText}</span>}
           </div>
         </section>
       ) : (
@@ -847,7 +1162,10 @@ function App() {
           }}
         >
           <div className="top-row">
-            <span className="badge">{getSourceLabel(config.heartRateSourceMode)}</span>
+            <span className="badge brand-badge">
+              <span className="brand-mark">♥</span>
+              <span>HeartDock</span>
+            </span>
 
             <div className="window-actions no-drag">
               <button
@@ -861,29 +1179,30 @@ function App() {
             </div>
           </div>
 
-          <div className="heart-row">
-            <span className="heart" style={{ color: bpmColor }}>
-              ♥
-            </span>
+          <div className={`heart-row heart-display-row ${displayGlowClass}`}>
+            {config.prefixText && (
+              <span className="heart prefix-text" style={{ color: bpmColor }}>
+                {config.prefixText}
+              </span>
+            )}
             <span className="bpm" style={{ color: bpmColor, fontSize: config.fontSize }}>
               {displayBpm}
             </span>
-            <span className="unit">bpm</span>
+            {config.unitText && <span className="unit">{config.unitText}</span>}
           </div>
 
           {config.showSettings && (
             <div className="settings-panel no-drag">
-              <label>
-                数据源
-                <select
-                  value={config.heartRateSourceMode}
-                  onChange={(event) => handleSourceModeChange(event.target.value as HeartRateSourceMode)}
-                >
-                  <option value="mock">模拟心率</option>
-                  <option value="manual">手动输入</option>
-                  <option value="ble">BLE 心率设备（实验）</option>
-                </select>
-              </label>
+              <div className="setting-field">
+                <span className="field-label">数据源</span>
+                {renderCustomSelect(
+                  'source-mode',
+                  config.heartRateSourceMode,
+                  sourceModeOptions,
+                  handleSourceModeChange,
+                  '选择心率数据源'
+                )}
+              </div>
 
               {config.heartRateSourceMode === 'mock' && (
                 <div className="source-panel">
@@ -1009,21 +1328,128 @@ function App() {
                 纯享模式下可以按住心率本体拖动位置，双击心率区域退出纯享模式。设置页面右下角的斜纹手柄可以拖动调整窗口大小。
               </p>
 
-              <label>
-                主题预设
-                <select
-                  value={config.themePresetId}
-                  onChange={(event) => handleThemeChange(event.target.value as ThemePresetId)}
-                >
-                  {themePresets.map((theme) => (
-                    <option key={theme.id} value={theme.id}>
-                      {theme.name}
-                    </option>
-                  ))}
-                </select>
-              </label>
+              <div className="settings-section">
+                <div className="section-heading">
+                  <span>显示样式</span>
+                  <small>自定义心率前缀、单位、颜色和发光效果。</small>
+                </div>
 
-              <p className="hint">{currentTheme.description}</p>
+                <label>
+                  前缀标识
+                  <input
+                    type="text"
+                    maxLength={8}
+                    value={config.prefixText}
+                    placeholder="例如 ♥ / HR / 心率"
+                    onChange={(event) => handlePrefixTextChange(event.target.value)}
+                  />
+                </label>
+
+                <label>
+                  单位文字
+                  <input
+                    type="text"
+                    maxLength={8}
+                    value={config.unitText}
+                    placeholder="例如 bpm / BPM / 次/分"
+                    onChange={(event) => handleUnitTextChange(event.target.value)}
+                  />
+                </label>
+
+                <div className="setting-field">
+                  <span className="field-label">颜色模式</span>
+                  {renderCustomSelect(
+                    'color-mode',
+                    config.colorMode,
+                    colorModeOptions,
+                    (value) => updateConfig('colorMode', value),
+                    '选择心率颜色模式'
+                  )}
+                </div>
+
+                {config.colorMode === 'fixed' && (
+                  <div className="setting-field">
+                    <span className="field-label">固定颜色</span>
+                    <details className="color-editor-details">
+                      <summary>
+                        <span className="summary-color-dot" style={{ backgroundColor: config.fixedColor }} />
+                        <span>{config.fixedColor}</span>
+                        <span className="summary-hint">展开编辑</span>
+                      </summary>
+                      {renderColorControl(config.fixedColor, handleFixedColorChange, '固定心率颜色')}
+                    </details>
+                  </div>
+                )}
+
+                <div className="setting-field">
+                  <span className="field-label">发光强度</span>
+                  {renderCustomSelect(
+                    'glow-level',
+                    config.glowLevel,
+                    glowLevelOptions,
+                    (value) => updateConfig('glowLevel', value),
+                    '选择心率发光强度'
+                  )}
+                </div>
+
+                <div className="color-rules-editor">
+                  <div className="color-rules-header">
+                    <span className="color-rules-title">区间颜色规则</span>
+                    <small>范围限制为 30 - 240 bpm，点击每段可展开编辑。</small>
+                  </div>
+
+                  {config.colorRules.map((rule, index) => (
+                    <details
+                      key={`color-rule-${index}`}
+                      className="color-rule-card"
+                      open={openColorRuleIndexes.includes(index)}
+                      onToggle={(event) => handleColorRuleToggle(index, event.currentTarget.open)}
+                    >
+                      <summary>
+                        <span className="summary-color-dot" style={{ backgroundColor: rule.color }} />
+                        <span>
+                          {rule.min} - {rule.max} bpm
+                        </span>
+                        <span className="summary-hex">{rule.color}</span>
+                      </summary>
+
+                      <div className="color-rule-card-body">
+                        <div className="color-rule-range-inputs">
+                          <label>
+                            下限
+                            {renderRangeControl(
+                              rule.min,
+                              (value) => handleColorRuleRangeChange(index, 'min', value),
+                              (delta) => handleColorRuleRangeStep(index, 'min', delta),
+                              `${rule.min} 到 ${rule.max} bpm 的下限`
+                            )}
+                          </label>
+
+                          <label>
+                            上限
+                            {renderRangeControl(
+                              rule.max,
+                              (value) => handleColorRuleRangeChange(index, 'max', value),
+                              (delta) => handleColorRuleRangeStep(index, 'max', delta),
+                              `${rule.min} 到 ${rule.max} bpm 的上限`
+                            )}
+                          </label>
+                        </div>
+
+                        {renderColorControl(
+                          rule.color,
+                          (color) => handleColorRuleColorChange(index, color),
+                          `${rule.min} 到 ${rule.max} bpm 区间颜色`
+                        )}
+                      </div>
+                    </details>
+                  ))}
+                </div>
+
+                <p className="hint">
+                  区间范围和颜色只在“跟随心率区间”模式下生效；固定颜色模式会始终使用同一种颜色。
+                </p>
+              </div>
 
               <label>
                 字体大小

--- a/src/renderer/src/config.ts
+++ b/src/renderer/src/config.ts
@@ -4,20 +4,11 @@ export interface ColorRule {
   color: string
 }
 
-export type ThemePresetId = 'default' | 'transparent' | 'highContrast' | 'streamer'
 export type HeartRateSourceMode = 'mock' | 'manual' | 'ble'
-
-export interface ThemePreset {
-  id: ThemePresetId
-  name: string
-  description: string
-  fontSize: number
-  backgroundOpacity: number
-  colorRules: ColorRule[]
-}
+export type HeartRateColorMode = 'range' | 'fixed'
+export type DisplayGlowLevel = 'off' | 'soft' | 'medium' | 'strong'
 
 export interface HeartDockConfig {
-  themePresetId: ThemePresetId
   heartRateSourceMode: HeartRateSourceMode
   mockPaused: boolean
   manualBpm: number
@@ -28,62 +19,15 @@ export interface HeartDockConfig {
   clickThrough: boolean
   showSettings: boolean
   pureDisplay: boolean
+  prefixText: string
+  unitText: string
+  colorMode: HeartRateColorMode
+  fixedColor: string
+  glowLevel: DisplayGlowLevel
   colorRules: ColorRule[]
 }
 
-export const themePresets: ThemePreset[] = [
-  {
-    id: 'default',
-    name: '默认主题',
-    description: '适合日常桌面显示的基础主题。',
-    fontSize: 64,
-    backgroundOpacity: 0.24,
-    colorRules: [
-      { min: 0, max: 90, color: '#4ade80' },
-      { min: 91, max: 120, color: '#facc15' },
-      { min: 121, max: 240, color: '#fb7185' }
-    ]
-  },
-  {
-    id: 'transparent',
-    name: '透明主题',
-    description: '更轻量的透明显示效果，适合覆盖在窗口上。',
-    fontSize: 64,
-    backgroundOpacity: 0.08,
-    colorRules: [
-      { min: 0, max: 90, color: '#93c5fd' },
-      { min: 91, max: 120, color: '#fde68a' },
-      { min: 121, max: 240, color: '#fda4af' }
-    ]
-  },
-  {
-    id: 'highContrast',
-    name: '高对比度主题',
-    description: '更强的对比度，适合复杂背景或远距离观看。',
-    fontSize: 72,
-    backgroundOpacity: 0.68,
-    colorRules: [
-      { min: 0, max: 90, color: '#22c55e' },
-      { min: 91, max: 120, color: '#eab308' },
-      { min: 121, max: 240, color: '#ef4444' }
-    ]
-  },
-  {
-    id: 'streamer',
-    name: '直播醒目主题',
-    description: '更大的数字和更明显的颜色，适合直播/录制画面。',
-    fontSize: 84,
-    backgroundOpacity: 0.36,
-    colorRules: [
-      { min: 0, max: 90, color: '#38bdf8' },
-      { min: 91, max: 120, color: '#facc15' },
-      { min: 121, max: 240, color: '#fb7185' }
-    ]
-  }
-]
-
 export const defaultConfig: HeartDockConfig = {
-  themePresetId: 'default',
   heartRateSourceMode: 'mock',
   mockPaused: false,
   manualBpm: 78,
@@ -94,30 +38,19 @@ export const defaultConfig: HeartDockConfig = {
   clickThrough: false,
   showSettings: true,
   pureDisplay: false,
+  prefixText: '♥',
+  unitText: 'bpm',
+  colorMode: 'range',
+  fixedColor: '#4ade80',
+  glowLevel: 'medium',
   colorRules: [
-    { min: 0, max: 90, color: '#4ade80' },
+    { min: 30, max: 90, color: '#4ade80' },
     { min: 91, max: 120, color: '#facc15' },
     { min: 121, max: 240, color: '#fb7185' }
   ]
 }
 
 const CONFIG_KEY = 'heartdock.config.v1'
-
-export function getThemePreset(id: ThemePresetId): ThemePreset {
-  return themePresets.find((theme) => theme.id === id) ?? themePresets[0]
-}
-
-export function applyThemePreset(config: HeartDockConfig, themeId: ThemePresetId): HeartDockConfig {
-  const theme = getThemePreset(themeId)
-
-  return {
-    ...config,
-    themePresetId: theme.id,
-    fontSize: theme.fontSize,
-    backgroundOpacity: theme.backgroundOpacity,
-    colorRules: theme.colorRules
-  }
-}
 
 export function normalizeBpm(value: number): number {
   if (!Number.isFinite(value)) {
@@ -135,6 +68,60 @@ export function normalizeRefreshIntervalMs(value: number): number {
   const roundedValue = Math.round(value / 250) * 250
 
   return Math.min(Math.max(roundedValue, 250), 10000)
+}
+
+export function normalizeDisplayText(value: unknown, fallback: string, maxLength = 8): string {
+  if (typeof value !== 'string') {
+    return fallback
+  }
+
+  return value.slice(0, maxLength)
+}
+
+export function normalizeColor(value: unknown, fallback: string): string {
+  if (typeof value !== 'string') {
+    return fallback
+  }
+
+  return /^#[0-9a-fA-F]{6}$/.test(value) ? value : fallback
+}
+
+export function normalizeColorMode(value: unknown): HeartRateColorMode {
+  return value === 'fixed' || value === 'range' ? value : defaultConfig.colorMode
+}
+
+export function normalizeGlowLevel(value: unknown): DisplayGlowLevel {
+  return value === 'off' || value === 'soft' || value === 'medium' || value === 'strong'
+    ? value
+    : defaultConfig.glowLevel
+}
+
+export function normalizeColorRules(value: unknown): ColorRule[] {
+  const fallbackRules = defaultConfig.colorRules
+
+  if (!Array.isArray(value)) {
+    return fallbackRules.map((rule) => ({ ...rule }))
+  }
+
+  return fallbackRules.map((fallbackRule, index) => {
+    const parsedRule = value[index] as Partial<ColorRule> | undefined
+    const rawMin =
+      typeof parsedRule?.min === 'number' && Number.isFinite(parsedRule.min)
+        ? Math.round(parsedRule.min)
+        : fallbackRule.min
+    const rawMax =
+      typeof parsedRule?.max === 'number' && Number.isFinite(parsedRule.max)
+        ? Math.round(parsedRule.max)
+        : fallbackRule.max
+    const min = Math.min(Math.max(rawMin, 30), 240)
+    const max = Math.min(Math.max(rawMax, min), 240)
+
+    return {
+      min,
+      max,
+      color: normalizeColor(parsedRule?.color, fallbackRule.color)
+    }
+  })
 }
 
 export function loadConfig(): HeartDockConfig {
@@ -157,7 +144,12 @@ export function loadConfig(): HeartDockConfig {
       clickThrough: Boolean(parsed.clickThrough ?? defaultConfig.clickThrough),
       showSettings: Boolean(parsed.showSettings ?? defaultConfig.showSettings),
       pureDisplay: Boolean(parsed.pureDisplay ?? defaultConfig.pureDisplay),
-      colorRules: parsed.colorRules ?? [...defaultConfig.colorRules]
+      prefixText: normalizeDisplayText(parsed.prefixText, defaultConfig.prefixText, 8),
+      unitText: normalizeDisplayText(parsed.unitText, defaultConfig.unitText, 8),
+      colorMode: normalizeColorMode(parsed.colorMode),
+      fixedColor: normalizeColor(parsed.fixedColor, defaultConfig.fixedColor),
+      glowLevel: normalizeGlowLevel(parsed.glowLevel),
+      colorRules: normalizeColorRules(parsed.colorRules)
     }
   } catch {
     return createDefaultConfig()
@@ -176,6 +168,11 @@ export function createDefaultConfig(): HeartDockConfig {
     clickThrough: defaultConfig.clickThrough,
     showSettings: defaultConfig.showSettings,
     pureDisplay: defaultConfig.pureDisplay,
-    colorRules: [...defaultConfig.colorRules]
+    prefixText: normalizeDisplayText(defaultConfig.prefixText, '♥', 8),
+    unitText: normalizeDisplayText(defaultConfig.unitText, 'bpm', 8),
+    colorMode: defaultConfig.colorMode,
+    fixedColor: normalizeColor(defaultConfig.fixedColor, '#4ade80'),
+    glowLevel: defaultConfig.glowLevel,
+    colorRules: normalizeColorRules(defaultConfig.colorRules)
   }
 }

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -73,7 +73,7 @@ select {
   outline: 0;
   border-radius: 24px;
   color: white;
-  background-color: rgba(15, 23, 42, 0.92);
+  background-color: rgba(11, 18, 32, 0.96);
   backdrop-filter: none;
   box-shadow: none;
 }
@@ -109,6 +109,32 @@ select {
   font-size: 12px;
   letter-spacing: 0.08em;
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+}
+
+.brand-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 5px 12px;
+  border-color: rgba(125, 211, 252, 0.28);
+  background:
+    linear-gradient(180deg, rgba(15, 23, 42, 0.9), rgba(8, 13, 24, 0.92));
+  box-shadow:
+    0 0 0 3px rgba(56, 189, 248, 0.05),
+    inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  letter-spacing: 0.02em;
+}
+
+.brand-mark {
+  display: grid;
+  width: 18px;
+  height: 18px;
+  place-items: center;
+  border-radius: 999px;
+  color: #38bdf8;
+  background: rgba(56, 189, 248, 0.12);
+  font-size: 12px;
+  filter: drop-shadow(0 0 8px rgba(56, 189, 248, 0.55));
 }
 
 .window-actions {
@@ -211,12 +237,12 @@ select {
   padding: 14px 14px 42px;
   overflow-y: auto;
   overscroll-behavior: contain;
-  border: 1px solid rgba(148, 163, 184, 0.14);
+  border: 1px solid rgba(148, 163, 184, 0.22);
   border-radius: 20px;
   color: rgba(248, 250, 252, 0.92);
   background:
-    linear-gradient(180deg, rgba(17, 24, 39, 0.96), rgba(15, 23, 42, 0.96)),
-    #0f172a;
+    linear-gradient(180deg, rgba(20, 31, 52, 0.98), rgba(13, 22, 39, 0.98)),
+    #101827;
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
   scrollbar-width: thin;
   scrollbar-color: rgba(148, 163, 184, 0.54) transparent;
@@ -258,6 +284,7 @@ select {
 }
 
 .settings-panel input[type='number'],
+.settings-panel input[type='text'],
 .settings-panel select {
   width: 100%;
   height: 38px;
@@ -266,7 +293,7 @@ select {
   border-radius: 14px;
   color: rgba(248, 250, 252, 0.96);
   outline: none;
-  background: #0b1220;
+  background: #08111f;
   transition:
     border-color 0.16s ease,
     box-shadow 0.16s ease,
@@ -274,14 +301,16 @@ select {
 }
 
 .settings-panel input[type='number']:hover,
+.settings-panel input[type='text']:hover,
 .settings-panel select:hover {
   border-color: rgba(125, 211, 252, 0.36);
 }
 
 .settings-panel input[type='number']:focus,
+.settings-panel input[type='text']:focus,
 .settings-panel select:focus {
   border-color: rgba(56, 189, 248, 0.88);
-  background: #0b1220;
+  background: #08111f;
   box-shadow:
     0 0 0 3px rgba(56, 189, 248, 0.16),
     0 0 18px rgba(56, 189, 248, 0.12);
@@ -583,6 +612,495 @@ select {
     inset 0 2px 8px rgba(0, 0, 0, 0.28);
 }
 
+
+.settings-section {
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+  border: 1px solid rgba(56, 189, 248, 0.24);
+  border-radius: 18px;
+  background:
+    linear-gradient(180deg, rgba(25, 37, 61, 0.92), rgba(15, 23, 42, 0.98)),
+    #111c30;
+}
+
+.section-heading {
+  display: grid;
+  gap: 3px;
+  padding-bottom: 2px;
+}
+
+.section-heading span {
+  color: rgba(248, 250, 252, 0.96);
+  font-size: 14px;
+  font-weight: 800;
+}
+
+.section-heading small {
+  color: rgba(203, 213, 225, 0.6);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.custom-select {
+  position: relative;
+  min-width: 0;
+  z-index: 20;
+}
+
+.custom-select.is-open {
+  z-index: 40;
+}
+
+.custom-select-trigger {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  min-height: 40px;
+  padding: 8px 12px;
+  border: 1px solid rgba(125, 211, 252, 0.24);
+  border-radius: 14px;
+  color: rgba(248, 250, 252, 0.95);
+  background:
+    linear-gradient(180deg, rgba(8, 17, 31, 0.98), rgba(11, 18, 32, 0.98));
+  cursor: pointer;
+  text-align: left;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.06),
+    0 7px 16px rgba(0, 0, 0, 0.12);
+  transition:
+    border-color 0.16s ease,
+    background 0.16s ease,
+    box-shadow 0.16s ease,
+    transform 0.16s ease;
+}
+
+.custom-select-trigger:hover,
+.custom-select.is-open .custom-select-trigger {
+  border-color: rgba(56, 189, 248, 0.62);
+  background:
+    linear-gradient(180deg, rgba(14, 37, 63, 0.98), rgba(10, 18, 32, 0.98));
+  box-shadow:
+    0 0 0 3px rgba(56, 189, 248, 0.12),
+    0 10px 22px rgba(0, 0, 0, 0.16),
+    inset 0 1px 0 rgba(255, 255, 255, 0.08);
+}
+
+.custom-select-value {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-weight: 700;
+}
+
+.custom-select-chevron {
+  color: rgba(125, 211, 252, 0.82);
+  font-size: 13px;
+  transform: translateY(-1px);
+  transition: transform 0.16s ease;
+}
+
+.custom-select.is-open .custom-select-chevron {
+  transform: rotate(180deg) translateY(1px);
+}
+
+.custom-select-menu {
+  position: absolute;
+  top: calc(100% + 7px);
+  right: 0;
+  left: 0;
+  display: grid;
+  gap: 6px;
+  padding: 7px;
+  border: 1px solid rgba(125, 211, 252, 0.24);
+  border-radius: 16px;
+  background:
+    linear-gradient(180deg, rgba(17, 27, 46, 0.98), rgba(8, 14, 26, 0.98));
+  box-shadow:
+    0 18px 38px rgba(0, 0, 0, 0.38),
+    0 0 0 1px rgba(255, 255, 255, 0.03),
+    inset 0 1px 0 rgba(255, 255, 255, 0.06);
+}
+
+.custom-select-option {
+  display: grid;
+  gap: 2px;
+  width: 100%;
+  padding: 9px 10px;
+  border: 1px solid transparent;
+  border-radius: 12px;
+  color: rgba(248, 250, 252, 0.92);
+  background: transparent;
+  cursor: pointer;
+  text-align: left;
+  transition:
+    border-color 0.14s ease,
+    background 0.14s ease,
+    transform 0.14s ease;
+}
+
+.custom-select-option:hover {
+  transform: translateY(-1px);
+  border-color: rgba(125, 211, 252, 0.24);
+  background: rgba(56, 189, 248, 0.1);
+}
+
+.custom-select-option.is-selected {
+  border-color: rgba(56, 189, 248, 0.42);
+  background:
+    linear-gradient(180deg, rgba(14, 116, 144, 0.26), rgba(30, 64, 105, 0.2));
+}
+
+.custom-select-option span {
+  font-size: 13px;
+  font-weight: 800;
+}
+
+.custom-select-option small {
+  color: rgba(203, 213, 225, 0.58);
+  font-size: 11px;
+  line-height: 1.35;
+}
+
+
+.setting-field {
+  display: grid;
+  grid-template-columns: 112px 1fr;
+  align-items: start;
+  gap: 12px;
+  color: rgba(248, 250, 252, 0.86);
+  font-size: 14px;
+}
+
+.field-label {
+  padding-top: 7px;
+}
+
+.custom-color-control {
+  display: grid;
+  gap: 10px;
+  min-width: 0;
+  padding: 10px;
+  border-top: 1px solid rgba(148, 163, 184, 0.12);
+}
+
+.color-editor-details,
+.color-rule-card {
+  border: 1px solid rgba(125, 211, 252, 0.18);
+  border-radius: 16px;
+  background:
+    linear-gradient(180deg, rgba(22, 33, 55, 0.96), rgba(13, 22, 39, 0.96));
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.04),
+    0 8px 18px rgba(0, 0, 0, 0.12);
+  overflow: hidden;
+}
+
+.color-editor-details summary,
+.color-rule-card summary {
+  display: grid;
+  grid-template-columns: 24px auto 1fr;
+  align-items: center;
+  gap: 10px;
+  min-height: 42px;
+  padding: 9px 11px;
+  color: rgba(248, 250, 252, 0.9);
+  cursor: pointer;
+  list-style: none;
+}
+
+.color-editor-details summary::-webkit-details-marker,
+.color-rule-card summary::-webkit-details-marker {
+  display: none;
+}
+
+.color-editor-details summary::after,
+.color-rule-card summary::after {
+  content: "展开";
+  justify-self: end;
+  color: rgba(125, 211, 252, 0.74);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.color-editor-details[open] summary::after,
+.color-rule-card[open] summary::after {
+  content: "收起";
+}
+
+.summary-color-dot {
+  width: 20px;
+  height: 20px;
+  border: 1px solid rgba(248, 250, 252, 0.32);
+  border-radius: 999px;
+  box-shadow:
+    0 0 0 3px rgba(15, 23, 42, 0.72),
+    0 0 14px currentColor;
+}
+
+.summary-hex,
+.summary-hint {
+  justify-self: start;
+  color: rgba(203, 213, 225, 0.58);
+  font-size: 12px;
+  font-family:
+    ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    Monaco,
+    Consolas,
+    "Liberation Mono",
+    monospace;
+}
+
+.color-preview-card {
+  display: grid;
+  grid-template-columns: 38px 1fr;
+  align-items: center;
+  gap: 10px;
+}
+
+.color-preview {
+  width: 38px;
+  height: 38px;
+  border: 1px solid rgba(248, 250, 252, 0.28);
+  border-radius: 14px;
+  box-shadow:
+    0 0 0 3px rgba(15, 23, 42, 0.76),
+    0 0 18px currentColor;
+}
+
+.hex-input-wrap {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.hex-input-wrap small {
+  color: rgba(203, 213, 225, 0.52);
+  font-size: 11px;
+  line-height: 1.35;
+}
+
+.hex-color-input {
+  height: 34px !important;
+  padding: 6px 10px !important;
+  border-radius: 12px !important;
+  font-family:
+    ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    Monaco,
+    Consolas,
+    "Liberation Mono",
+    monospace !important;
+  font-size: 13px !important;
+}
+
+.color-swatch-grid {
+  display: grid;
+  grid-template-columns: repeat(10, minmax(18px, 1fr));
+  gap: 7px;
+}
+
+.color-swatch-button {
+  width: 100%;
+  min-width: 20px;
+  height: 24px;
+  border: 1px solid rgba(248, 250, 252, 0.22);
+  border-radius: 999px;
+  cursor: pointer;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.18),
+    0 4px 10px rgba(0, 0, 0, 0.16);
+  transition:
+    transform 0.14s ease,
+    border-color 0.14s ease,
+    box-shadow 0.14s ease;
+}
+
+.color-swatch-button:hover {
+  transform: translateY(-1px);
+  border-color: rgba(248, 250, 252, 0.72);
+  box-shadow:
+    0 0 0 3px rgba(56, 189, 248, 0.12),
+    0 8px 16px rgba(0, 0, 0, 0.2);
+}
+
+.color-swatch-button.is-active {
+  border-color: rgba(248, 250, 252, 0.95);
+  box-shadow:
+    0 0 0 3px rgba(56, 189, 248, 0.18),
+    0 0 18px rgba(56, 189, 248, 0.24);
+}
+
+.color-rules-editor {
+  display: grid;
+  gap: 8px;
+  padding: 10px;
+  border: 1px solid rgba(125, 211, 252, 0.16);
+  border-radius: 16px;
+  background:
+    linear-gradient(180deg, rgba(9, 15, 28, 0.72), rgba(9, 15, 28, 0.88));
+}
+
+.color-rules-header {
+  display: grid;
+  gap: 3px;
+}
+
+.color-rules-title {
+  color: rgba(248, 250, 252, 0.9);
+  font-size: 13px;
+  font-weight: 800;
+}
+
+.color-rules-header small {
+  color: rgba(203, 213, 225, 0.54);
+  font-size: 11px;
+  line-height: 1.35;
+}
+
+.color-rule-card-body {
+  display: grid;
+  gap: 10px;
+  padding: 10px;
+  border-top: 1px solid rgba(148, 163, 184, 0.1);
+}
+
+.color-rule-range-inputs {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.settings-panel .color-rule-range-inputs label {
+  grid-template-columns: 42px 1fr;
+  gap: 8px;
+  color: rgba(226, 232, 240, 0.78);
+  font-size: 12px;
+}
+
+.range-field {
+  display: grid;
+  grid-template-columns: minmax(64px, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.range-value-input {
+  width: 100%;
+  height: 34px !important;
+  padding: 0 10px !important;
+  border: 1px solid rgba(125, 211, 252, 0.22) !important;
+  border-radius: 12px !important;
+  color: rgba(248, 250, 252, 0.96);
+  background:
+    linear-gradient(180deg, rgba(8, 17, 31, 0.98), rgba(11, 18, 32, 0.98)) !important;
+  text-align: center;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.05),
+    0 6px 14px rgba(0, 0, 0, 0.1) !important;
+}
+
+.range-value-input:focus {
+  outline: none;
+  border-color: rgba(56, 189, 248, 0.62) !important;
+  background: rgba(10, 24, 45, 0.98) !important;
+}
+
+.range-action-row {
+  display: grid;
+  grid-template-columns: repeat(2, 40px);
+  gap: 6px;
+}
+
+.range-action-button {
+  display: grid;
+  width: 40px;
+  height: 34px;
+  place-items: center;
+  padding: 0;
+  border: 1px solid rgba(125, 211, 252, 0.18);
+  border-radius: 12px;
+  color: rgba(224, 242, 254, 0.86);
+  background:
+    linear-gradient(180deg, rgba(18, 34, 57, 0.94), rgba(10, 18, 32, 0.98));
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 850;
+  line-height: 1;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.05),
+    0 5px 12px rgba(0, 0, 0, 0.12);
+  transition:
+    background 0.14s ease,
+    border-color 0.14s ease,
+    color 0.14s ease,
+    transform 0.14s ease,
+    box-shadow 0.14s ease;
+}
+
+.range-action-button:hover {
+  color: #ffffff;
+  border-color: rgba(186, 230, 253, 0.48);
+  background:
+    linear-gradient(180deg, rgba(56, 189, 248, 0.32), rgba(30, 64, 105, 0.76));
+  box-shadow:
+    0 0 0 3px rgba(56, 189, 248, 0.1),
+    0 8px 16px rgba(0, 0, 0, 0.16),
+    inset 0 1px 0 rgba(255, 255, 255, 0.08);
+}
+
+.range-action-button:active {
+  transform: scale(0.94);
+}
+
+
+.heart-display-row.glow-off .heart,
+.heart-display-row.glow-off .bpm {
+  filter: none;
+  text-shadow: none;
+}
+
+.heart-display-row.glow-soft .heart {
+  filter: drop-shadow(0 0 8px currentColor);
+}
+
+.heart-display-row.glow-soft .bpm {
+  text-shadow: 0 0 12px currentColor;
+}
+
+.heart-display-row.glow-medium .heart {
+  filter: drop-shadow(0 0 14px currentColor);
+}
+
+.heart-display-row.glow-medium .bpm {
+  text-shadow: 0 0 24px currentColor;
+}
+
+.heart-display-row.glow-strong .heart {
+  filter:
+    drop-shadow(0 0 16px currentColor)
+    drop-shadow(0 0 28px currentColor);
+}
+
+.heart-display-row.glow-strong .bpm {
+  text-shadow:
+    0 0 18px currentColor,
+    0 0 36px currentColor,
+    0 0 54px currentColor;
+}
+
+.prefix-text {
+  min-width: max-content;
+  letter-spacing: normal;
+}
+
+
 .source-panel {
   display: grid;
   gap: 8px;
@@ -590,7 +1108,7 @@ select {
   border: 1px solid rgba(148, 163, 184, 0.16);
   border-radius: 16px;
   color: rgba(248, 250, 252, 0.88);
-  background: #111827;
+  background: #162033;
 }
 
 .secondary-button,
@@ -666,7 +1184,7 @@ select {
   border: 1px solid rgba(148, 163, 184, 0.16);
   border-radius: 14px;
   color: rgba(255, 255, 255, 0.84);
-  background: #111827;
+  background: #162033;
   font-size: 14px;
 }
 
@@ -680,7 +1198,7 @@ select {
   padding: 8px 10px;
   border-radius: 12px;
   color: rgba(226, 232, 240, 0.8);
-  background: #0f172a;
+  background: #111c30;
   font-size: 13px;
 }
 


### PR DESCRIPTION
## 本次修改

- 支持自定义心率前缀标识
- 支持自定义心率单位文字
- 支持选择心率颜色模式：跟随区间颜色 / 固定颜色
- 支持自定义固定心率颜色
- 支持编辑心率区间颜色和心率范围
- 支持区间范围自动顺延，避免相邻区间重叠
- 支持调整心率数字发光强度
- 移除主题预设，避免与自定义显示样式重复
- 将数据源、颜色模式、发光强度改为自定义下拉菜单
- 将区间范围调整改为自定义数字输入和 `-1` / `+1` 控件
- 普通显示模式和纯享模式同步应用自定义样式
- 保持模拟心率、手动心率和 BLE 心率逻辑不变

## 测试

- 已测试默认显示仍保持正常
- 已测试自定义前缀标识生效
- 已测试自定义单位文字生效
- 已测试固定颜色模式生效
- 已测试心率区间颜色模式生效
- 已测试区间颜色编辑生效
- 已测试区间范围编辑生效
- 已测试相邻区间会自动顺延，避免重叠
- 已测试发光强度切换正常
- 已测试自定义下拉菜单切换正常
- 已测试普通设置页面和纯享模式显示一致
- 已测试 BLE 心率显示正常
- 已测试纯享模式拖动和退出正常
- 已测试设置窗口缩放正常
- 已运行 npm run typecheck

## 关联 Issue

Closes #37