### PR TITLE
feat: 增加显示框样式预设

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,6 +1,7 @@
-import { app, BrowserWindow, globalShortcut, ipcMain, screen } from 'electron'
-import { existsSync, readFileSync, writeFileSync } from 'node:fs'
-import { join } from 'node:path'
+import { app, BrowserWindow, dialog, globalShortcut, ipcMain, net, protocol, screen, type OpenDialogOptions } from 'electron'
+import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { basename, extname, join } from 'node:path'
+import { pathToFileURL } from 'node:url'
 
 interface WindowState {
   width: number
@@ -14,6 +15,12 @@ interface WindowBounds {
   y: number
   width: number
   height: number
+}
+
+interface DisplayBackgroundImageResult {
+  assetFileName: string
+  fileName: string
+  url: string
 }
 
 let overlayWindow: BrowserWindow | null = null
@@ -36,8 +43,116 @@ const MAX_WINDOW_STATE: WindowState = {
   height: 900
 }
 
+const BACKGROUND_IMAGE_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.webp', '.gif'])
+
+protocol.registerSchemesAsPrivileged([
+  {
+    scheme: 'heartdock',
+    privileges: {
+      standard: true,
+      secure: true,
+      supportFetchAPI: true,
+      bypassCSP: true,
+      stream: true
+    }
+  }
+])
+
 function getWindowStatePath(): string {
   return join(app.getPath('userData'), 'window-state.json')
+}
+
+function getAssetDirectory(): string {
+  return join(app.getPath('userData'), 'assets')
+}
+
+function getDisplayBackgroundImageUrl(assetFileName: string): string {
+  return 'heartdock://asset/' + encodeURIComponent(assetFileName)
+}
+
+function isSupportedBackgroundImagePath(filePath: string): boolean {
+  return BACKGROUND_IMAGE_EXTENSIONS.has(extname(filePath).toLowerCase())
+}
+
+function getSafeAssetFileName(filePath: string): string {
+  const extension = extname(filePath).toLowerCase()
+  const rawName = basename(filePath, extension)
+  const safeName =
+    rawName
+      .replace(/[^a-zA-Z0-9_-]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 40) || 'background'
+
+  return safeName + '-' + Date.now() + extension
+}
+
+function registerHeartDockProtocol(): void {
+  protocol.handle('heartdock', (request) => {
+    const parsedUrl = new URL(request.url)
+
+    if (parsedUrl.hostname !== 'asset') {
+      return new Response('Not found', { status: 404 })
+    }
+
+    const assetFileName = decodeURIComponent(parsedUrl.pathname.replace(/^\/+/, ''))
+
+    if (
+      !assetFileName ||
+      basename(assetFileName) !== assetFileName ||
+      !BACKGROUND_IMAGE_EXTENSIONS.has(extname(assetFileName).toLowerCase())
+    ) {
+      return new Response('Bad request', { status: 400 })
+    }
+
+    const filePath = join(getAssetDirectory(), assetFileName)
+
+    if (!existsSync(filePath)) {
+      return new Response('Not found', { status: 404 })
+    }
+
+    return net.fetch(pathToFileURL(filePath).toString())
+  })
+}
+
+async function selectDisplayBackgroundImage(): Promise<DisplayBackgroundImageResult | null> {
+  const dialogOptions: OpenDialogOptions = {
+    title: '选择心率背景图片',
+    properties: ['openFile'],
+    filters: [
+      {
+        name: '图片文件',
+        extensions: ['png', 'jpg', 'jpeg', 'webp', 'gif']
+      }
+    ]
+  }
+
+  const result = overlayWindow
+    ? await dialog.showOpenDialog(overlayWindow, dialogOptions)
+    : await dialog.showOpenDialog(dialogOptions)
+
+  if (result.canceled || !result.filePaths[0]) {
+    return null
+  }
+
+  const sourcePath = result.filePaths[0]
+
+  if (!isSupportedBackgroundImagePath(sourcePath)) {
+    throw new Error('不支持的图片格式。请选择 png、jpg、jpeg、webp 或 gif 图片。')
+  }
+
+  const assetDirectory = getAssetDirectory()
+  mkdirSync(assetDirectory, { recursive: true })
+
+  const assetFileName = getSafeAssetFileName(sourcePath)
+  const targetPath = join(assetDirectory, assetFileName)
+
+  copyFileSync(sourcePath, targetPath)
+
+  return {
+    assetFileName,
+    fileName: basename(sourcePath),
+    url: getDisplayBackgroundImageUrl(assetFileName)
+  }
 }
 
 function clampNumber(value: unknown, min: number, max: number, fallback: number): number {
@@ -234,6 +349,10 @@ function registerIpcHandlers(): void {
     overlayWindow?.close()
   })
 
+  ipcMain.handle('overlay:select-display-background-image', () => {
+    return selectDisplayBackgroundImage()
+  })
+
   ipcMain.handle('overlay:move-window-by', (_event, deltaX: number, deltaY: number) => {
     if (!overlayWindow || overlayWindow.isDestroyed()) {
       return false
@@ -307,7 +426,6 @@ function registerIpcHandlers(): void {
     }
   )
 
-
   ipcMain.handle('set-always-on-top', (_event, value: boolean) => {
     return setOverlayAlwaysOnTop(value)
   })
@@ -358,7 +476,7 @@ function createOverlayWindow(): void {
   overlayWindow.webContents.on('did-finish-load', () => {
     console.log('[HeartDock] renderer loaded')
   })
-  
+
   overlayWindow.webContents.on('select-bluetooth-device', (event, deviceList, callback) => {
     event.preventDefault()
 
@@ -421,6 +539,7 @@ function createOverlayWindow(): void {
 }
 
 app.whenReady().then(() => {
+  registerHeartDockProtocol()
   registerIpcHandlers()
   createOverlayWindow()
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -7,6 +7,12 @@ interface HeartDockWindowBounds {
   height: number
 }
 
+interface DisplayBackgroundImageResult {
+  assetFileName: string
+  fileName: string
+  url: string
+}
+
 contextBridge.exposeInMainWorld('heartdock', {
   setAlwaysOnTop: (enabled: boolean) => ipcRenderer.invoke('overlay:set-always-on-top', enabled),
   setClickThrough: (enabled: boolean) => ipcRenderer.invoke('overlay:set-click-through', enabled),
@@ -17,6 +23,8 @@ contextBridge.exposeInMainWorld('heartdock', {
     ipcRenderer.invoke('overlay:set-window-bounds', bounds),
   moveWindowBy: (deltaX: number, deltaY: number) =>
     ipcRenderer.invoke('overlay:move-window-by', deltaX, deltaY),
+  selectDisplayBackgroundImage: (): Promise<DisplayBackgroundImageResult | null> =>
+    ipcRenderer.invoke('overlay:select-display-background-image'),
   onClickThroughChanged: (callback: (enabled: boolean) => void) => {
     const listener = (_event: Electron.IpcRendererEvent, enabled: boolean) => callback(enabled)
     ipcRenderer.on('overlay:click-through-changed', listener)

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -9,7 +9,9 @@ import {
 } from 'react'
 
 import {
+  DisplayBackgroundImageFit,
   DisplayGlowLevel,
+  DisplayStylePreset,
   HeartDockConfig,
   HeartRateColorMode,
   HeartRateSourceMode,
@@ -17,6 +19,7 @@ import {
   loadConfig,
   normalizeBpm,
   normalizeColor,
+  normalizeDisplayBackgroundImageOpacity,
   normalizeDisplayText,
   normalizeRefreshIntervalMs,
   saveConfig
@@ -60,6 +63,20 @@ const glowLevelOptions: Array<SelectOption<DisplayGlowLevel>> = [
   { value: 'soft', label: '弱', description: '轻微发光。' },
   { value: 'medium', label: '中', description: '默认发光强度。' },
   { value: 'strong', label: '强', description: '更醒目的发光效果。' }
+]
+
+const backgroundImageFitOptions: Array<SelectOption<DisplayBackgroundImageFit>> = [
+  { value: 'contain', label: '完整显示', description: '完整显示图片，可能留出空白。' },
+  { value: 'cover', label: '铺满裁切', description: '铺满背景区域，边缘可能被裁切。' },
+  { value: 'stretch', label: '拉伸填满', description: '强制填满区域，可能改变图片比例。' }
+]
+
+const displayStylePresetOptions: Array<SelectOption<DisplayStylePreset>> = [
+  { value: 'none', label: '无背景', description: '只显示心率文字，适合最干净的纯享叠加。' },
+  { value: 'glass', label: '柔和玻璃卡片', description: '半透明玻璃质感，适合日常桌面。' },
+  { value: 'capsule', label: '圆角胶囊', description: '紧凑的圆角胶囊框，适合小尺寸悬浮。' },
+  { value: 'neon', label: '霓虹直播框', description: '带弱发光边框，适合直播和录屏。' },
+  { value: 'kawaii', label: '二次元贴纸风', description: '粉蓝渐变、爱心和星星点缀，偏可爱风。' }
 ]
 
 interface BleCharacteristic {
@@ -229,6 +246,12 @@ function App() {
   )
   const isPureDisplay = config.pureDisplay
   const displayGlowClass = `glow-${config.glowLevel}`
+  const hasDisplayBackgroundImage = false
+  const effectiveDisplayStylePreset =
+    config.displayStylePreset === 'image-card' ? 'none' : config.displayStylePreset
+  const hasDisplayFrame = effectiveDisplayStylePreset !== 'none'
+  const displayStylePresetClass = `display-style-${effectiveDisplayStylePreset}`
+  const displayBackgroundFitClass = `display-background-fit-${config.displayBackgroundImageFit}`
 
   useEffect(() => {
     sourceModeRef.current = config.heartRateSourceMode
@@ -251,7 +274,7 @@ function App() {
   }, [config.alwaysOnTop])
 
   useEffect(() => {
-    if (config.pureDisplay) {
+    if (config.pureDisplay && !config.clickThrough) {
       return
     }
 
@@ -259,16 +282,19 @@ function App() {
   }, [config.clickThrough, config.pureDisplay])
 
   useEffect(() => {
-    if (!config.pureDisplay) {
+    if (!config.pureDisplay || config.clickThrough) {
       return
     }
 
-    let isHeartInteractive = false
+    const setTemporaryClickThrough = (enabled: boolean): void => {
+      void window.heartdock.setClickThrough(enabled)
+    }
 
-    const updatePureDisplayHitTest = (event: MouseEvent): void => {
+    const updatePureHeartHitTest = (event: MouseEvent): void => {
       const rect = pureHeartRef.current?.getBoundingClientRect()
 
       if (!rect) {
+        setTemporaryClickThrough(true)
         return
       }
 
@@ -278,20 +304,21 @@ function App() {
         event.clientY >= rect.top &&
         event.clientY <= rect.bottom
 
-      if (isInsideHeart === isHeartInteractive) {
-        return
-      }
-
-      isHeartInteractive = isInsideHeart
-      window.heartdock.setClickThrough(!isInsideHeart)
+      setTemporaryClickThrough(!isInsideHeart)
     }
 
-    window.heartdock.setClickThrough(true)
-    window.addEventListener('mousemove', updatePureDisplayHitTest)
+    const handleWindowMouseLeave = (): void => {
+      setTemporaryClickThrough(true)
+    }
+
+    setTemporaryClickThrough(true)
+    window.addEventListener('mousemove', updatePureHeartHitTest)
+    window.addEventListener('mouseleave', handleWindowMouseLeave)
 
     return () => {
-      window.removeEventListener('mousemove', updatePureDisplayHitTest)
-      window.heartdock.setClickThrough(config.clickThrough)
+      window.removeEventListener('mousemove', updatePureHeartHitTest)
+      window.removeEventListener('mouseleave', handleWindowMouseLeave)
+      void window.heartdock.setClickThrough(config.clickThrough)
     }
   }, [config.clickThrough, config.pureDisplay])
 
@@ -472,28 +499,27 @@ function App() {
           </span>
         </button>
 
-        {isOpen && (
-          <div className="custom-select-menu" role="listbox">
-            {options.map((option) => (
-              <button
-                key={option.value}
-                className={`custom-select-option ${option.value === value ? 'is-selected' : ''}`}
-                type="button"
-                role="option"
-                aria-selected={option.value === value}
-                onClick={(event) => {
-                  event.preventDefault()
-                  event.stopPropagation()
-                  onChange(option.value)
-                  setOpenSelectId(null)
-                }}
-              >
-                <span>{option.label}</span>
-                {option.description && <small>{option.description}</small>}
-              </button>
-            ))}
-          </div>
-        )}
+        <div className="custom-select-menu" role="listbox" aria-hidden={!isOpen}>
+          {options.map((option) => (
+            <button
+              key={option.value}
+              className={`custom-select-option ${option.value === value ? 'is-selected' : ''}`}
+              type="button"
+              role="option"
+              tabIndex={isOpen ? 0 : -1}
+              aria-selected={option.value === value}
+              onClick={(event) => {
+                event.preventDefault()
+                event.stopPropagation()
+                onChange(option.value)
+                setOpenSelectId(null)
+              }}
+            >
+              <span>{option.label}</span>
+              {option.description && <small>{option.description}</small>}
+            </button>
+          ))}
+        </div>
       </div>
     )
   }
@@ -606,6 +632,69 @@ function App() {
   )
 
 
+  const handleSelectDisplayBackgroundImage = async (): Promise<void> => {
+    try {
+      const result = await window.heartdock.selectDisplayBackgroundImage()
+
+      if (!result) {
+        return
+      }
+
+      setConfig((current) => ({
+        ...current,
+        displayBackgroundImageEnabled: true,
+        displayBackgroundImageUrl: result.url,
+        displayBackgroundImageAssetFileName: result.assetFileName,
+        displayBackgroundImageName: result.fileName,
+        displayStylePreset: 'image-card'
+      }))
+    } catch (error) {
+      const message = error instanceof Error ? error.message : '选择背景图片失败。'
+      window.alert(message)
+    }
+  }
+
+  const handleClearDisplayBackgroundImage = (): void => {
+    setConfig((current) => ({
+      ...current,
+      displayBackgroundImageEnabled: false,
+      displayBackgroundImageUrl: '',
+      displayBackgroundImageAssetFileName: '',
+      displayBackgroundImageName: '',
+      displayStylePreset: current.displayStylePreset === 'image-card' ? 'none' : current.displayStylePreset
+    }))
+  }
+
+  const handleDisplayBackgroundImageEnabledChange = (enabled: boolean): void => {
+    if (enabled && !config.displayBackgroundImageUrl) {
+      void handleSelectDisplayBackgroundImage()
+      return
+    }
+
+    updateConfig('displayBackgroundImageEnabled', enabled)
+  }
+
+  const handleDisplayBackgroundImageOpacityChange = (value: number): void => {
+    updateConfig('displayBackgroundImageOpacity', normalizeDisplayBackgroundImageOpacity(value))
+  }
+
+  const renderDisplayBackgroundImageLayer = () => {
+    if (!hasDisplayBackgroundImage) {
+      return null
+    }
+
+    return (
+      <span
+        className="display-background-image"
+        aria-hidden="true"
+        style={{
+          backgroundImage: `url("${config.displayBackgroundImageUrl}")`,
+          opacity: config.displayBackgroundImageOpacity
+        }}
+      />
+    )
+  }
+
   const handleTogglePureDisplay = async (): Promise<void> => {
     if (!config.pureDisplay) {
       normalWindowBoundsRef.current = await window.heartdock.getWindowBounds()
@@ -685,11 +774,24 @@ function App() {
       void window.heartdock.moveWindowBy(deltaX, deltaY)
     }
 
-    const handleMouseUp = (): void => {
+    const handleMouseUp = (upEvent: MouseEvent): void => {
       pureDragStateRef.current.isDragging = false
 
       window.removeEventListener('mousemove', handleMouseMove)
       window.removeEventListener('mouseup', handleMouseUp)
+
+      if (config.pureDisplay && !config.clickThrough) {
+        const rect = pureHeartRef.current?.getBoundingClientRect()
+        const isInsideHeart = Boolean(
+          rect &&
+            upEvent.clientX >= rect.left &&
+            upEvent.clientX <= rect.right &&
+            upEvent.clientY >= rect.top &&
+            upEvent.clientY <= rect.bottom
+        )
+
+        void window.heartdock.setClickThrough(!isInsideHeart)
+      }
 
       window.setTimeout(() => {
         pureDragMovedRef.current = false
@@ -773,7 +875,7 @@ function App() {
       return
     }
 
-    const characteristic = event.target as BleCharacteristic | null
+    const characteristic = event.target as unknown as BleCharacteristic | null
     const value = characteristic?.value
 
     if (!value) {
@@ -1098,6 +1200,17 @@ function App() {
     updateConfig('refreshIntervalMs', nextRefreshIntervalMs)
   }
 
+  const handleRefreshIntervalStep = (delta: number): void => {
+    const parsed = Number(refreshIntervalInput.trim())
+    const currentValue = Number.isFinite(parsed)
+      ? normalizeRefreshIntervalMs(parsed)
+      : normalizeRefreshIntervalMs(config.refreshIntervalMs)
+    const nextRefreshIntervalMs = normalizeRefreshIntervalMs(currentValue + delta)
+
+    setRefreshIntervalInput(String(nextRefreshIntervalMs))
+    updateConfig('refreshIntervalMs', nextRefreshIntervalMs)
+  }
+
   const handleRefreshIntervalKeyDown = (event: KeyboardEvent<HTMLInputElement>): void => {
     if (event.key === 'Enter') {
       applyRefreshIntervalMs()
@@ -1129,27 +1242,33 @@ function App() {
       {isPureDisplay ? (
         <section className="pure-display-view no-drag">
           <div
-            ref={pureHeartRef}
-            className={`pure-heart-row heart-display-row ${displayGlowClass}`}
-            title="按住拖动位置，双击退出纯享模式"
-            onMouseDown={handlePureDisplayMouseDown}
-            onDoubleClick={handlePureDisplayDoubleClick}
-            onMouseEnter={() => window.heartdock.setClickThrough(false)}
-            onMouseLeave={() => {
-              if (!pureDragStateRef.current.isDragging) {
-                window.heartdock.setClickThrough(true)
-              }
-            }}
+            className={`display-background-frame pure-display-frame ${displayStylePresetClass} ${
+              hasDisplayFrame ? 'has-display-frame' : ''
+            } ${hasDisplayBackgroundImage ? 'has-display-background' : ''} ${displayBackgroundFitClass}`}
           >
-            {config.prefixText && (
-              <span className="heart prefix-text pure-heart" style={{ color: bpmColor }}>
-                {config.prefixText}
+            {renderDisplayBackgroundImageLayer()}
+            <div
+              ref={pureHeartRef}
+              className={`pure-heart-row heart-display-row ${displayGlowClass}`}
+              aria-label="按住拖动位置，双击退出纯享模式"
+              onMouseDown={handlePureDisplayMouseDown}
+              onMouseLeave={() => {
+                if (config.pureDisplay && !config.clickThrough) {
+                  void window.heartdock.setClickThrough(true)
+                }
+              }}
+              onDoubleClick={handlePureDisplayDoubleClick}
+            >
+              {config.prefixText && (
+                <span className="heart prefix-text pure-heart" style={{ color: bpmColor }}>
+                  {config.prefixText}
+                </span>
+              )}
+              <span className="bpm pure-bpm" style={{ color: bpmColor, fontSize: config.fontSize }}>
+                {displayBpm}
               </span>
-            )}
-            <span className="bpm pure-bpm" style={{ color: bpmColor, fontSize: config.fontSize }}>
-              {displayBpm}
-            </span>
-            {config.unitText && <span className="unit pure-unit">{config.unitText}</span>}
+              {config.unitText && <span className="unit pure-unit">{config.unitText}</span>}
+            </div>
           </div>
         </section>
       ) : (
@@ -1179,16 +1298,23 @@ function App() {
             </div>
           </div>
 
-          <div className={`heart-row heart-display-row ${displayGlowClass}`}>
-            {config.prefixText && (
-              <span className="heart prefix-text" style={{ color: bpmColor }}>
-                {config.prefixText}
+          <div
+            className={`display-background-frame normal-display-frame ${displayStylePresetClass} ${
+              hasDisplayFrame ? 'has-display-frame' : ''
+            } ${hasDisplayBackgroundImage ? 'has-display-background' : ''} ${displayBackgroundFitClass}`}
+          >
+            {renderDisplayBackgroundImageLayer()}
+            <div className={`heart-row heart-display-row ${displayGlowClass}`}>
+              {config.prefixText && (
+                <span className="heart prefix-text" style={{ color: bpmColor }}>
+                  {config.prefixText}
+                </span>
+              )}
+              <span className="bpm" style={{ color: bpmColor, fontSize: config.fontSize }}>
+                {displayBpm}
               </span>
-            )}
-            <span className="bpm" style={{ color: bpmColor, fontSize: config.fontSize }}>
-              {displayBpm}
-            </span>
-            {config.unitText && <span className="unit">{config.unitText}</span>}
+              {config.unitText && <span className="unit">{config.unitText}</span>}
+            </div>
           </div>
 
           {config.showSettings && (
@@ -1356,6 +1482,7 @@ function App() {
                   />
                 </label>
 
+
                 <div className="setting-field">
                   <span className="field-label">颜色模式</span>
                   {renderCustomSelect(
@@ -1451,6 +1578,23 @@ function App() {
                 </p>
               </div>
 
+              <div className="settings-section">
+                <div className="section-heading">
+                  <span>显示框样式</span>
+                </div>
+
+                <div className="setting-field">
+                  <span className="field-label">显示样式</span>
+                  {renderCustomSelect(
+                    'display-style-preset',
+                    config.displayStylePreset === 'image-card' ? 'none' : config.displayStylePreset,
+                    displayStylePresetOptions,
+                    (value) => updateConfig('displayStylePreset', value),
+                    '选择心率显示框样式'
+                  )}
+                </div>
+              </div>
+
               <label>
                 字体大小
                 <input
@@ -1464,16 +1608,51 @@ function App() {
 
               <label>
                 模拟心率刷新间隔 ms
-                <input
-                  type="number"
-                  min="250"
-                  max="10000"
-                  step="250"
-                  value={refreshIntervalInput}
-                  onChange={(event) => setRefreshIntervalInput(event.target.value)}
-                  onBlur={applyRefreshIntervalMs}
-                  onKeyDown={handleRefreshIntervalKeyDown}
-                />
+                <div className="range-field refresh-interval-field" aria-label="模拟心率刷新间隔">
+                  <input
+                    className="range-value-input refresh-interval-input"
+                    type="text"
+                    inputMode="numeric"
+                    value={refreshIntervalInput}
+                    onChange={(event) => {
+                      const nextValue = event.target.value.trim()
+
+                      if (/^\d{0,5}$/.test(nextValue)) {
+                        setRefreshIntervalInput(nextValue)
+                      }
+                    }}
+                    onBlur={applyRefreshIntervalMs}
+                    onKeyDown={handleRefreshIntervalKeyDown}
+                  />
+
+                  <div className="range-action-row refresh-interval-actions">
+                    <button
+                      className="range-action-button"
+                      type="button"
+                      aria-label="减少 250 毫秒"
+                      onClick={(event) => {
+                        event.preventDefault()
+                        event.stopPropagation()
+                        handleRefreshIntervalStep(-250)
+                      }}
+                    >
+                      −250
+                    </button>
+
+                    <button
+                      className="range-action-button"
+                      type="button"
+                      aria-label="增加 250 毫秒"
+                      onClick={(event) => {
+                        event.preventDefault()
+                        event.stopPropagation()
+                        handleRefreshIntervalStep(250)
+                      }}
+                    >
+                      +250
+                    </button>
+                  </div>
+                </div>
               </label>
 
               <p className="hint">

--- a/src/renderer/src/config.ts
+++ b/src/renderer/src/config.ts
@@ -7,6 +7,8 @@ export interface ColorRule {
 export type HeartRateSourceMode = 'mock' | 'manual' | 'ble'
 export type HeartRateColorMode = 'range' | 'fixed'
 export type DisplayGlowLevel = 'off' | 'soft' | 'medium' | 'strong'
+export type DisplayBackgroundImageFit = 'contain' | 'cover' | 'stretch'
+export type DisplayStylePreset = 'none' | 'glass' | 'capsule' | 'neon' | 'kawaii' | 'image-card'
 
 export interface HeartDockConfig {
   heartRateSourceMode: HeartRateSourceMode
@@ -25,6 +27,13 @@ export interface HeartDockConfig {
   fixedColor: string
   glowLevel: DisplayGlowLevel
   colorRules: ColorRule[]
+  displayBackgroundImageEnabled: boolean
+  displayBackgroundImageUrl: string
+  displayBackgroundImageAssetFileName: string
+  displayBackgroundImageName: string
+  displayBackgroundImageOpacity: number
+  displayBackgroundImageFit: DisplayBackgroundImageFit
+  displayStylePreset: DisplayStylePreset
 }
 
 export const defaultConfig: HeartDockConfig = {
@@ -38,7 +47,7 @@ export const defaultConfig: HeartDockConfig = {
   clickThrough: false,
   showSettings: true,
   pureDisplay: false,
-  prefixText: '♥',
+  prefixText: '\u2665',
   unitText: 'bpm',
   colorMode: 'range',
   fixedColor: '#4ade80',
@@ -47,7 +56,14 @@ export const defaultConfig: HeartDockConfig = {
     { min: 30, max: 90, color: '#4ade80' },
     { min: 91, max: 120, color: '#facc15' },
     { min: 121, max: 240, color: '#fb7185' }
-  ]
+  ],
+  displayBackgroundImageEnabled: false,
+  displayBackgroundImageUrl: '',
+  displayBackgroundImageAssetFileName: '',
+  displayBackgroundImageName: '',
+  displayBackgroundImageOpacity: 0.85,
+  displayBackgroundImageFit: 'contain',
+  displayStylePreset: 'none'
 }
 
 const CONFIG_KEY = 'heartdock.config.v1'
@@ -94,6 +110,31 @@ export function normalizeGlowLevel(value: unknown): DisplayGlowLevel {
   return value === 'off' || value === 'soft' || value === 'medium' || value === 'strong'
     ? value
     : defaultConfig.glowLevel
+}
+
+export function normalizeDisplayBackgroundImageFit(value: unknown): DisplayBackgroundImageFit {
+  return value === 'contain' || value === 'cover' || value === 'stretch'
+    ? value
+    : defaultConfig.displayBackgroundImageFit
+}
+
+export function normalizeDisplayBackgroundImageOpacity(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return defaultConfig.displayBackgroundImageOpacity
+  }
+
+  return Math.min(Math.max(value, 0), 1)
+}
+
+export function normalizeDisplayStylePreset(value: unknown): DisplayStylePreset {
+  return value === 'none' ||
+    value === 'glass' ||
+    value === 'capsule' ||
+    value === 'neon' ||
+    value === 'kawaii' ||
+    value === 'image-card'
+    ? value
+    : defaultConfig.displayStylePreset
 }
 
 export function normalizeColorRules(value: unknown): ColorRule[] {
@@ -149,7 +190,30 @@ export function loadConfig(): HeartDockConfig {
       colorMode: normalizeColorMode(parsed.colorMode),
       fixedColor: normalizeColor(parsed.fixedColor, defaultConfig.fixedColor),
       glowLevel: normalizeGlowLevel(parsed.glowLevel),
-      colorRules: normalizeColorRules(parsed.colorRules)
+      colorRules: normalizeColorRules(parsed.colorRules),
+      displayBackgroundImageEnabled: Boolean(
+        parsed.displayBackgroundImageEnabled ?? defaultConfig.displayBackgroundImageEnabled
+      ),
+      displayBackgroundImageUrl: normalizeDisplayText(
+        parsed.displayBackgroundImageUrl,
+        defaultConfig.displayBackgroundImageUrl,
+        2048
+      ),
+      displayBackgroundImageAssetFileName: normalizeDisplayText(
+        parsed.displayBackgroundImageAssetFileName,
+        defaultConfig.displayBackgroundImageAssetFileName,
+        256
+      ),
+      displayBackgroundImageName: normalizeDisplayText(
+        parsed.displayBackgroundImageName,
+        defaultConfig.displayBackgroundImageName,
+        128
+      ),
+      displayBackgroundImageOpacity: normalizeDisplayBackgroundImageOpacity(
+        parsed.displayBackgroundImageOpacity
+      ),
+      displayBackgroundImageFit: normalizeDisplayBackgroundImageFit(parsed.displayBackgroundImageFit),
+      displayStylePreset: normalizeDisplayStylePreset(parsed.displayStylePreset)
     }
   } catch {
     return createDefaultConfig()
@@ -168,11 +232,18 @@ export function createDefaultConfig(): HeartDockConfig {
     clickThrough: defaultConfig.clickThrough,
     showSettings: defaultConfig.showSettings,
     pureDisplay: defaultConfig.pureDisplay,
-    prefixText: normalizeDisplayText(defaultConfig.prefixText, '♥', 8),
+    prefixText: normalizeDisplayText(defaultConfig.prefixText, '\u2665', 8),
     unitText: normalizeDisplayText(defaultConfig.unitText, 'bpm', 8),
     colorMode: defaultConfig.colorMode,
     fixedColor: normalizeColor(defaultConfig.fixedColor, '#4ade80'),
     glowLevel: defaultConfig.glowLevel,
-    colorRules: normalizeColorRules(defaultConfig.colorRules)
+    colorRules: normalizeColorRules(defaultConfig.colorRules),
+    displayBackgroundImageEnabled: defaultConfig.displayBackgroundImageEnabled,
+    displayBackgroundImageUrl: defaultConfig.displayBackgroundImageUrl,
+    displayBackgroundImageAssetFileName: defaultConfig.displayBackgroundImageAssetFileName,
+    displayBackgroundImageName: defaultConfig.displayBackgroundImageName,
+    displayBackgroundImageOpacity: defaultConfig.displayBackgroundImageOpacity,
+    displayBackgroundImageFit: defaultConfig.displayBackgroundImageFit,
+    displayStylePreset: defaultConfig.displayStylePreset
   }
 }

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -29,16 +29,27 @@ body,
   background: transparent;
 }
 
+input::selection,
+textarea::selection,
+[contenteditable='true']::selection {
+  color: #ffffff;
+  background: rgba(56, 189, 248, 0.42);
+}
+
 button,
 input,
-select {
+select,
+textarea {
   font: inherit;
 }
 
 input,
-select {
+select,
+textarea,
+[contenteditable='true'] {
   user-select: text;
   -webkit-user-select: text;
+  caret-color: #7dd3fc;
 }
 
 button {
@@ -57,7 +68,9 @@ button {
 .no-drag,
 input,
 button,
-select {
+select,
+textarea,
+[contenteditable='true'] {
   -webkit-app-region: no-drag;
 }
 
@@ -228,6 +241,69 @@ select {
   color: rgba(255, 255, 255, 0.82);
   font-size: 20px;
   font-weight: 700;
+}
+
+.display-background-frame {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  isolation: isolate;
+}
+
+.normal-display-frame {
+  width: 100%;
+  margin: 14px 0 18px;
+  border-radius: 24px;
+}
+
+.normal-display-frame .heart-row {
+  position: relative;
+  z-index: 1;
+  margin: 0;
+}
+
+.display-background-frame.has-display-background {
+  border: 1px solid rgba(125, 211, 252, 0.22);
+  background:
+    linear-gradient(180deg, rgba(15, 23, 42, 0.28), rgba(2, 6, 23, 0.18));
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.06),
+    0 12px 28px rgba(0, 0, 0, 0.14);
+}
+
+.normal-display-frame.has-display-background {
+  min-height: 150px;
+  padding: 26px 24px;
+}
+
+.display-background-image {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  background-position: center;
+  background-repeat: no-repeat;
+  pointer-events: none;
+}
+
+.display-background-fit-contain .display-background-image {
+  background-size: contain;
+}
+
+.display-background-fit-cover .display-background-image {
+  background-size: cover;
+}
+
+.display-background-fit-stretch .display-background-image {
+  background-size: 100% 100%;
+}
+
+.display-background-frame.has-display-background .heart-display-row {
+  padding: 8px 14px;
+  border-radius: 999px;
+  background: rgba(2, 6, 23, 0.16);
+  backdrop-filter: blur(1px);
 }
 
 .settings-panel {
@@ -707,21 +783,73 @@ select {
 }
 
 .custom-select-menu {
-  position: absolute;
-  top: calc(100% + 7px);
-  right: 0;
-  left: 0;
+  position: static;
   display: grid;
+  max-height: 0;
   gap: 6px;
-  padding: 7px;
-  border: 1px solid rgba(125, 211, 252, 0.24);
+  margin-top: 0;
+  padding: 0 7px;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  border: 1px solid rgba(125, 211, 252, 0);
   border-radius: 16px;
   background:
     linear-gradient(180deg, rgba(17, 27, 46, 0.98), rgba(8, 14, 26, 0.98));
   box-shadow:
-    0 18px 38px rgba(0, 0, 0, 0.38),
+    0 12px 26px rgba(0, 0, 0, 0),
+    0 0 0 1px rgba(255, 255, 255, 0),
+    inset 0 1px 0 rgba(255, 255, 255, 0);
+  opacity: 0;
+  pointer-events: none;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(125, 211, 252, 0.48) transparent;
+  transform: translateY(-6px);
+  visibility: hidden;
+  transition:
+    max-height 0.22s ease,
+    margin-top 0.18s ease,
+    padding 0.18s ease,
+    border-color 0.18s ease,
+    box-shadow 0.18s ease,
+    opacity 0.18s ease,
+    transform 0.18s ease,
+    visibility 0s linear 0.18s;
+}
+
+.custom-select.is-open .custom-select-menu {
+  max-height: clamp(168px, 38vh, 280px);
+  margin-top: 7px;
+  padding: 7px;
+  border-color: rgba(125, 211, 252, 0.24);
+  box-shadow:
+    0 12px 26px rgba(0, 0, 0, 0.26),
     0 0 0 1px rgba(255, 255, 255, 0.03),
     inset 0 1px 0 rgba(255, 255, 255, 0.06);
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateY(0);
+  visibility: visible;
+  transition-delay: 0s;
+}
+
+.custom-select-menu::-webkit-scrollbar {
+  width: 8px;
+}
+
+.custom-select-menu::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.custom-select-menu::-webkit-scrollbar-thumb {
+  border: 2px solid transparent;
+  border-radius: 999px;
+  background: rgba(125, 211, 252, 0.48);
+  background-clip: content-box;
+}
+
+.custom-select-menu::-webkit-scrollbar-thumb:hover {
+  background: rgba(186, 230, 253, 0.68);
+  background-clip: content-box;
 }
 
 .custom-select-option {
@@ -734,11 +862,19 @@ select {
   color: rgba(248, 250, 252, 0.92);
   background: transparent;
   cursor: pointer;
+  opacity: 0;
   text-align: left;
+  transform: translateY(-4px);
   transition:
     border-color 0.14s ease,
     background 0.14s ease,
-    transform 0.14s ease;
+    opacity 0.16s ease,
+    transform 0.16s ease;
+}
+
+.custom-select.is-open .custom-select-option {
+  opacity: 1;
+  transform: translateY(0);
 }
 
 .custom-select-option:hover {
@@ -1060,6 +1196,28 @@ select {
 }
 
 
+.refresh-interval-field {
+  grid-template-columns: 96px auto;
+  justify-content: start;
+  justify-self: start;
+  width: auto;
+  max-width: 240px;
+}
+
+.refresh-interval-input {
+  width: 96px !important;
+}
+
+.refresh-interval-actions {
+  grid-template-columns: repeat(2, 54px);
+}
+
+.refresh-interval-actions .range-action-button {
+  width: 54px;
+  font-size: 12px;
+}
+
+
 .heart-display-row.glow-off .heart,
 .heart-display-row.glow-off .bpm {
   filter: none;
@@ -1100,6 +1258,43 @@ select {
   letter-spacing: normal;
 }
 
+
+.background-image-actions {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.background-file-row {
+  display: grid;
+  grid-template-columns: 88px 1fr;
+  align-items: center;
+  gap: 12px;
+  padding: 9px 10px;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  border-radius: 14px;
+  color: rgba(226, 232, 240, 0.78);
+  background: #162033;
+  font-size: 13px;
+}
+
+.background-file-row strong {
+  overflow: hidden;
+  color: rgba(248, 250, 252, 0.94);
+  font-size: 13px;
+  font-weight: 700;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.option-card-compact {
+  min-height: 64px;
+}
+
+.settings-panel input:disabled {
+  cursor: not-allowed;
+  opacity: 0.52;
+}
 
 .source-panel {
   display: grid;
@@ -1255,6 +1450,31 @@ select {
   margin: 0;
 }
 
+.pure-display-frame {
+  width: max-content;
+  height: max-content;
+  margin: 0;
+  border-radius: 28px;
+  cursor: grab;
+  pointer-events: auto;
+  -webkit-app-region: no-drag;
+}
+
+.pure-display-frame.has-display-background {
+  min-width: 300px;
+  min-height: 168px;
+  padding: 28px 32px;
+}
+
+.pure-display-frame:active {
+  cursor: grabbing;
+}
+
+.pure-display-frame .pure-heart-row {
+  position: relative;
+  z-index: 1;
+}
+
 .pure-heart-row {
   display: inline-flex;
   width: max-content;
@@ -1301,6 +1521,23 @@ select {
   filter: drop-shadow(0 0 18px currentColor);
 }
 
+@media (max-width: 620px) {
+  .background-image-actions {
+    grid-template-columns: 1fr;
+  }
+
+  .normal-display-frame.has-display-background {
+    min-height: 128px;
+    padding: 20px 16px;
+  }
+
+  .pure-display-frame.has-display-background {
+    min-width: 240px;
+    min-height: 138px;
+    padding: 22px 24px;
+  }
+}
+
 @keyframes pulse {
   0%,
   100% {
@@ -1336,4 +1573,336 @@ select {
     width: 34px;
     height: 34px;
   }
+}
+
+/* Display style presets -------------------------------------------------- */
+.display-background-frame {
+  transition:
+    border-color 0.18s ease,
+    background 0.18s ease,
+    box-shadow 0.18s ease,
+    filter 0.18s ease;
+}
+
+.display-background-frame::before,
+.display-background-frame::after {
+  position: absolute;
+  pointer-events: none;
+}
+
+.display-background-frame.has-display-frame .heart-display-row {
+  position: relative;
+  z-index: 2;
+}
+
+.display-background-frame.has-display-frame:not(.display-style-image-card) .heart-display-row {
+  background: transparent;
+  backdrop-filter: none;
+}
+
+.normal-display-frame.has-display-frame {
+  min-height: 132px;
+  padding: 24px 24px;
+}
+
+.pure-display-frame.has-display-frame {
+  min-width: 280px;
+  min-height: 132px;
+  padding: 26px 30px;
+}
+
+.display-style-none {
+  border: 0 !important;
+  background: transparent !important;
+  box-shadow: none !important;
+}
+
+.display-style-none .heart-display-row {
+  padding: 0 !important;
+  background: transparent !important;
+  backdrop-filter: none !important;
+}
+
+.display-style-glass {
+  border: 1px solid rgba(226, 232, 240, 0.24) !important;
+  border-radius: 28px;
+  background:
+    radial-gradient(circle at 22% 12%, rgba(125, 211, 252, 0.18), transparent 36%),
+    linear-gradient(145deg, rgba(248, 250, 252, 0.16), rgba(15, 23, 42, 0.26)) !important;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.18),
+    0 18px 40px rgba(2, 6, 23, 0.18) !important;
+  backdrop-filter: blur(10px);
+}
+
+.display-style-capsule {
+  width: max-content;
+  min-width: min(100%, 280px);
+  margin-right: auto;
+  margin-left: auto;
+  border: 1px solid rgba(125, 211, 252, 0.28) !important;
+  border-radius: 999px;
+  background:
+    linear-gradient(135deg, rgba(15, 23, 42, 0.82), rgba(30, 41, 59, 0.72)) !important;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.12),
+    0 12px 28px rgba(2, 6, 23, 0.2) !important;
+}
+
+.normal-display-frame.display-style-capsule.has-display-frame {
+  min-height: 0;
+  padding: 16px 28px;
+}
+
+.pure-display-frame.display-style-capsule.has-display-frame {
+  min-width: 0;
+  min-height: 0;
+  padding: 18px 30px;
+}
+
+.display-style-neon {
+  border: 1px solid rgba(56, 189, 248, 0.45) !important;
+  border-radius: 30px;
+  background:
+    radial-gradient(circle at 20% 70%, rgba(244, 114, 182, 0.18), transparent 36%),
+    radial-gradient(circle at 86% 30%, rgba(56, 189, 248, 0.18), transparent 34%),
+    rgba(2, 6, 23, 0.5) !important;
+  box-shadow:
+    0 0 0 3px rgba(56, 189, 248, 0.08),
+    0 0 28px rgba(56, 189, 248, 0.18),
+    0 0 52px rgba(244, 114, 182, 0.12),
+    inset 0 1px 0 rgba(255, 255, 255, 0.1) !important;
+}
+
+.display-style-neon::after {
+  content: "";
+  inset: 10px;
+  z-index: 1;
+  border: 1px solid rgba(244, 114, 182, 0.28);
+  border-radius: inherit;
+  filter: drop-shadow(0 0 10px rgba(244, 114, 182, 0.28));
+}
+
+.display-style-kawaii {
+  border: 1px solid rgba(251, 207, 232, 0.72) !important;
+  border-radius: 30px;
+  background:
+    radial-gradient(circle at 16% 24%, rgba(251, 207, 232, 0.82), transparent 22%),
+    radial-gradient(circle at 84% 26%, rgba(186, 230, 253, 0.78), transparent 24%),
+    linear-gradient(135deg, rgba(255, 241, 242, 0.72), rgba(219, 234, 254, 0.58) 48%, rgba(250, 245, 255, 0.72)) !important;
+  box-shadow:
+    0 18px 36px rgba(244, 114, 182, 0.13),
+    0 0 0 4px rgba(255, 255, 255, 0.08),
+    inset 0 1px 0 rgba(255, 255, 255, 0.42) !important;
+}
+
+.display-style-kawaii::before {
+  content: "♡";
+  top: 12px;
+  left: 16px;
+  z-index: 1;
+  color: rgba(244, 114, 182, 0.72);
+  font-size: 22px;
+  font-weight: 900;
+  text-shadow: 0 0 12px rgba(244, 114, 182, 0.36);
+  transform: rotate(-12deg);
+}
+
+.display-style-kawaii::after {
+  content: "✦";
+  right: 18px;
+  bottom: 12px;
+  z-index: 1;
+  color: rgba(56, 189, 248, 0.7);
+  font-size: 20px;
+  text-shadow: 0 0 12px rgba(56, 189, 248, 0.34);
+  transform: rotate(10deg);
+}
+
+.display-style-kawaii .unit {
+  color: rgba(255, 255, 255, 0.92);
+}
+
+.display-style-image-card.has-display-frame,
+.display-style-image-card.has-display-background {
+  border: 0 !important;
+  border-radius: 30px;
+  background: transparent !important;
+  box-shadow: none !important;
+  backdrop-filter: none;
+}
+
+.display-style-image-card:not(.has-display-background) {
+  border: 1px dashed rgba(125, 211, 252, 0.24) !important;
+  background:
+    linear-gradient(135deg, rgba(15, 23, 42, 0.38), rgba(30, 41, 59, 0.22)) !important;
+}
+
+.display-style-image-card.has-display-background .heart-display-row {
+  background: transparent !important;
+  backdrop-filter: none !important;
+}
+
+.display-style-image-card.has-display-background .bpm,
+.display-style-image-card.has-display-background .heart {
+  text-shadow:
+    0 2px 12px rgba(2, 6, 23, 0.48),
+    0 0 24px currentColor;
+}
+
+.display-background-frame.has-display-background .display-background-image {
+  border-radius: inherit;
+}
+
+.display-background-frame.has-display-background .heart-display-row {
+  z-index: 2;
+}
+
+/* Refine: pause image background UI and make the no-background preset truly clean. */
+.display-style-none,
+.normal-display-frame.display-style-none,
+.pure-display-frame.display-style-none {
+  min-width: 0 !important;
+  min-height: 0 !important;
+  border: 0 !important;
+  background: transparent !important;
+  box-shadow: none !important;
+  backdrop-filter: none !important;
+  filter: none !important;
+}
+
+.normal-display-frame.display-style-none {
+  padding: 0 !important;
+}
+
+.pure-display-frame.display-style-none {
+  padding: 0 !important;
+}
+
+.display-style-none::before,
+.display-style-none::after {
+  content: none !important;
+  display: none !important;
+}
+
+.display-style-none .heart-display-row,
+.display-style-none.has-display-frame .heart-display-row {
+  padding: 0 !important;
+  border: 0 !important;
+  background: transparent !important;
+  box-shadow: none !important;
+  backdrop-filter: none !important;
+  filter: none !important;
+}
+
+/* Keep the no-background preset visually clean, but do not override the user's glow strength.
+   Text glow is still controlled by .heart-display-row.glow-off / soft / medium / strong. */
+
+
+
+/* Refinement: keep the no-background preset clean while preserving text-only glow. */
+.display-background-frame.display-style-none,
+.normal-display-frame.display-style-none,
+.pure-display-frame.display-style-none {
+  overflow: visible !important;
+}
+
+.display-style-none .heart-display-row,
+.display-style-none.has-display-frame .heart-display-row {
+  padding: 10px 22px 12px !important;
+  overflow: visible !important;
+  background: transparent !important;
+  box-shadow: none !important;
+  filter: none !important;
+}
+
+.pure-display-frame.display-style-none {
+  overflow: visible !important;
+}
+
+.pure-display-frame.display-style-none .pure-heart-row {
+  padding: 10px 24px 12px !important;
+}
+
+.display-style-none .bpm,
+.display-style-none .heart,
+.display-style-none .unit {
+  position: relative;
+  z-index: 1;
+}
+
+.heart-display-row.glow-off .heart,
+.heart-display-row.glow-off .bpm {
+  filter: none !important;
+  text-shadow: none !important;
+}
+
+.heart-display-row.glow-soft .bpm {
+  filter: drop-shadow(0 0 8px currentColor) !important;
+  text-shadow: none !important;
+}
+
+.heart-display-row.glow-medium .bpm {
+  filter:
+    drop-shadow(0 0 10px currentColor)
+    drop-shadow(0 0 16px currentColor) !important;
+  text-shadow: none !important;
+}
+
+.heart-display-row.glow-strong .bpm {
+  filter:
+    drop-shadow(0 0 12px currentColor)
+    drop-shadow(0 0 22px currentColor)
+    drop-shadow(0 0 30px currentColor) !important;
+  text-shadow: none !important;
+}
+
+.heart-display-row.glow-soft .heart {
+  filter: drop-shadow(0 0 8px currentColor) !important;
+}
+
+.heart-display-row.glow-medium .heart {
+  filter: drop-shadow(0 0 14px currentColor) !important;
+}
+
+.heart-display-row.glow-strong .heart {
+  filter:
+    drop-shadow(0 0 16px currentColor)
+    drop-shadow(0 0 28px currentColor) !important;
+}
+
+.pure-heart-row:hover .bpm,
+.pure-heart-row:hover .heart {
+  transform: none;
+}
+
+.display-style-none .pure-heart-row:hover .bpm,
+.display-style-none .pure-heart-row:hover .heart {
+  filter: inherit;
+}
+
+
+/* Pure display hit area refinement: only the heart-rate row is interactive. */
+.pure-display-view,
+.pure-display-frame {
+  pointer-events: none !important;
+}
+
+.pure-display-frame {
+  cursor: default;
+}
+
+.pure-display-frame .display-background-image,
+.pure-display-frame::before,
+.pure-display-frame::after {
+  pointer-events: none !important;
+}
+
+.pure-display-frame .pure-heart-row {
+  pointer-events: auto !important;
+  cursor: grab;
+}
+
+.pure-display-frame .pure-heart-row:active {
+  cursor: grabbing;
 }

--- a/src/renderer/src/vite-env.d.ts
+++ b/src/renderer/src/vite-env.d.ts
@@ -7,6 +7,12 @@ interface HeartDockWindowBounds {
   height: number
 }
 
+interface DisplayBackgroundImageResult {
+  assetFileName: string
+  fileName: string
+  url: string
+}
+
 interface HeartDockApi {
   setAlwaysOnTop: (enabled: boolean) => Promise<boolean>
   setClickThrough: (enabled: boolean) => Promise<boolean>
@@ -15,6 +21,7 @@ interface HeartDockApi {
   getWindowBounds: () => Promise<HeartDockWindowBounds | null>
   setWindowBounds: (bounds: HeartDockWindowBounds) => Promise<boolean>
   moveWindowBy: (deltaX: number, deltaY: number) => Promise<boolean>
+  selectDisplayBackgroundImage: () => Promise<DisplayBackgroundImageResult | null>
   onClickThroughChanged: (callback: (enabled: boolean) => void) => () => void
 }
 


### PR DESCRIPTION
## 本次修改

- 新增显示框样式预设配置
- 支持无背景、柔和玻璃卡片、圆角胶囊、霓虹直播框、二次元贴纸风等显示样式
- 将显示框样式移动到独立设置区域
- 优化无背景模式，避免出现额外背景框感
- 保留心率数字和前缀本身的发光强度效果
- 优化纯享模式命中范围，仅心率本体区域触发交互
- 修复纯享模式下点击后命中范围异常变大的问题
- 优化自定义下拉菜单，支持内部滚动和展开过渡动画
- 优化模拟心率刷新间隔输入控件，改为紧凑输入和自定义步进按钮
- 修复输入框文本选中不可见的问题

## 测试

- 已运行 `npm run typecheck`
- 已测试显示框样式切换
- 已测试无背景模式显示效果
- 已测试发光强度仍然生效
- 已测试纯享模式拖动和双击退出
- 已测试纯享模式命中范围仅限心率本体
- 已测试下拉菜单不会溢出窗口
- 已测试输入框文本可以正常选中和编辑

## 说明

本次主要提交显示框样式预设和纯享交互修正。

自定义图片背景能力后续再单独整理，不在本 PR 中作为完整功能关闭。