### PR TITLE
chore: 发布前更新版本号到 v0.1.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "heartdock",
-  "version": "0.1.1",
+  "version": "0.1.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "heartdock",
-      "version": "0.1.1",
+      "version": "0.1.12",
       "license": "MIT",
       "dependencies": {
         "react": "18.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "heartdock",
-  "version": "0.1.1",
+  "version": "0.1.12",
   "description": "A customizable desktop heart rate overlay for Windows.",
   "author": "Your Name",
   "license": "AGPL-3.0-only",


### PR DESCRIPTION
## 本次修改

- 将 package.json 版本号更新为 0.1.12
- 同步更新 package-lock.json 中的版本号

## 测试

- 已运行 `npm run typecheck`
- 已运行 `npm run dist`
- 已成功生成 Windows NSIS 安装包：`HeartDock Setup 0.1.12.exe`
- 已测试 `release/win-unpacked/HeartDock.exe`
- 已测试 `release/HeartDock Setup 0.1.12.exe`

## 说明

本 PR 只同步发布版本号，不包含功能代码变更。

安装包文件不提交到仓库源码中，后续通过 GitHub Release 上传。