### PR TITLE
fix: 稳定鼠标穿透切换

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -25,6 +25,7 @@ interface DisplayBackgroundImageResult {
 
 let overlayWindow: BrowserWindow | null = null
 let clickThrough = false
+let lastClickThroughChangeTs = 0
 let isStartupView = true
 let saveWindowStateTimer: ReturnType<typeof setTimeout> | null = null
 let bluetoothSelectionTimer: ReturnType<typeof setTimeout> | null = null
@@ -422,7 +423,17 @@ function setOverlayAlwaysOnTop(value: boolean): boolean {
 }
 
 function setOverlayClickThrough(value: boolean): boolean {
+  if (value === clickThrough) {
+    return value
+  }
+
+  const now = Date.now()
+  if (now - lastClickThroughChangeTs < 200) {
+    return clickThrough
+  }
+
   clickThrough = value
+  lastClickThroughChangeTs = now
 
   if (!overlayWindow || overlayWindow.isDestroyed()) {
     return value

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -362,7 +362,13 @@ function App() {
       return
     }
 
-    const setTemporaryClickThrough = (enabled: boolean): void => {
+    let lastSentClickThrough: boolean | null = null
+
+    const applyClickThrough = (enabled: boolean): void => {
+      if (enabled === lastSentClickThrough) {
+        return
+      }
+      lastSentClickThrough = enabled
       void window.heartdock.setClickThrough(enabled)
     }
 
@@ -370,7 +376,7 @@ function App() {
       const rect = pureHeartRef.current?.getBoundingClientRect()
 
       if (!rect) {
-        setTemporaryClickThrough(true)
+        applyClickThrough(true)
         return
       }
 
@@ -380,14 +386,14 @@ function App() {
         event.clientY >= rect.top &&
         event.clientY <= rect.bottom
 
-      setTemporaryClickThrough(!isInsideHeart)
+      applyClickThrough(!isInsideHeart)
     }
 
     const handleWindowMouseLeave = (): void => {
-      setTemporaryClickThrough(true)
+      applyClickThrough(true)
     }
 
-    setTemporaryClickThrough(true)
+    applyClickThrough(true)
     window.addEventListener('mousemove', updatePureHeartHitTest)
     window.addEventListener('mouseleave', handleWindowMouseLeave)
 


### PR DESCRIPTION
## 本次修改

- 修复 / 缓解鼠标穿透关闭时偶发退出的问题
- 在主进程 `setOverlayClickThrough` 中增加同值 no-op 保护，避免重复调用 `setIgnoreMouseEvents`
- 增加轻量 200ms 最小间隔保护，减少极短时间内频繁切换导致的不稳定
- 在渲染进程纯享模式 hit-test 中增加去重，避免 mousemove 期间重复发送相同的 click-through IPC

## 测试

用户本地已测试：

- 设置页 `Ctrl + Shift + H` 连续切换：正常
- 纯享模式 `Ctrl + Shift + H`：正常
- 纯享拖动和双击退出：正常
- 是否闪退：无

命令检查：

- `npm run typecheck` 通过

## 范围说明

本 PR 只处理 #48 鼠标穿透关闭时偶发退出，不改变鼠标穿透语义。

用户发现“开启鼠标穿透后点击会传到底层窗口”，这是当前鼠标穿透的既有行为。该需求已单独记录为 #54「增加交互锁定模式」，不并入本次修复。

## 已知限制

- 200ms 防抖可能导致极快速连续按快捷键时第二次切换被忽略
- 纯享模式下快捷键与 hit-test 的交互语义仍可后续继续优化
- 如果特定环境中退出根因不止快速切换，本次修复可能是缓解而非完全根治

Closes #48
Refs #54