### PR TITLE
feat: 优化纯享模式体验并支持配置导入导出

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -23,11 +23,24 @@ interface DisplayBackgroundImageResult {
   url: string
 }
 
+interface ConfigFileOpenResult {
+  content: string
+  fileName: string
+}
+
+interface ConfigFileSaveResult {
+  fileName: string
+  filePath: string
+}
+
 let overlayWindow: BrowserWindow | null = null
+let overlayAlwaysOnTop = true
+let pureDisplayTopmost = false
 let clickThrough = false
 let hitTestPassthrough = false
 let clickThroughHotkeyLocked = false
 let clickThroughHotkeyUnlockTimer: ReturnType<typeof setTimeout> | null = null
+let pureDisplayTopmostTimer: ReturnType<typeof setInterval> | null = null
 let isStartupView = true
 let saveWindowStateTimer: ReturnType<typeof setTimeout> | null = null
 let bluetoothSelectionTimer: ReturnType<typeof setTimeout> | null = null
@@ -53,6 +66,8 @@ const MAX_WINDOW_STATE: WindowState = {
 }
 
 const BACKGROUND_IMAGE_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.webp', '.gif'])
+const CONFIG_FILE_MAX_BYTES = 1024 * 1024
+const PURE_DISPLAY_TOPMOST_REINFORCE_MS = 1200
 
 const ALLOWED_EXTERNAL_URLS = new Set([
   'https://github.com/HHS3188/heartdock',
@@ -187,6 +202,95 @@ async function selectDisplayBackgroundImage(): Promise<DisplayBackgroundImageRes
     assetFileName,
     fileName: basename(sourcePath),
     url: getDisplayBackgroundImageUrl(assetFileName)
+  }
+}
+
+function getConfigExportDefaultPath(): string {
+  const now = new Date()
+  const timestamp = [
+    now.getFullYear(),
+    String(now.getMonth() + 1).padStart(2, '0'),
+    String(now.getDate()).padStart(2, '0'),
+    '-',
+    String(now.getHours()).padStart(2, '0'),
+    String(now.getMinutes()).padStart(2, '0'),
+    String(now.getSeconds()).padStart(2, '0')
+  ].join('')
+
+  return join(app.getPath('documents'), `HeartDock-config-${timestamp}.json`)
+}
+
+async function exportConfigFile(content: unknown): Promise<ConfigFileSaveResult | null> {
+  if (typeof content !== 'string' || content.length === 0) {
+    throw new Error('配置内容为空，无法导出。')
+  }
+
+  if (Buffer.byteLength(content, 'utf8') > CONFIG_FILE_MAX_BYTES) {
+    throw new Error('配置内容过大，无法导出。')
+  }
+
+  const dialogOptions = {
+    title: '导出 HeartDock 配置文件',
+    defaultPath: getConfigExportDefaultPath(),
+    filters: [
+      {
+        name: 'JSON 配置文件',
+        extensions: ['json']
+      }
+    ]
+  }
+
+  const result = overlayWindow
+    ? await dialog.showSaveDialog(overlayWindow, dialogOptions)
+    : await dialog.showSaveDialog(dialogOptions)
+
+  if (result.canceled || !result.filePath) {
+    return null
+  }
+
+  writeFileSync(result.filePath, content, 'utf8')
+
+  return {
+    fileName: basename(result.filePath),
+    filePath: result.filePath
+  }
+}
+
+async function importConfigFile(): Promise<ConfigFileOpenResult | null> {
+  const dialogOptions: OpenDialogOptions = {
+    title: '载入 HeartDock 配置文件',
+    properties: ['openFile'],
+    filters: [
+      {
+        name: 'JSON 配置文件',
+        extensions: ['json']
+      }
+    ]
+  }
+
+  const result = overlayWindow
+    ? await dialog.showOpenDialog(overlayWindow, dialogOptions)
+    : await dialog.showOpenDialog(dialogOptions)
+
+  if (result.canceled || !result.filePaths[0]) {
+    return null
+  }
+
+  const sourcePath = result.filePaths[0]
+
+  if (extname(sourcePath).toLowerCase() !== '.json') {
+    throw new Error('不支持的配置文件格式。请选择 .json 文件。')
+  }
+
+  const content = readFileSync(sourcePath, 'utf8')
+
+  if (Buffer.byteLength(content, 'utf8') > CONFIG_FILE_MAX_BYTES) {
+    throw new Error('配置文件过大，无法载入。')
+  }
+
+  return {
+    content,
+    fileName: basename(sourcePath)
   }
 }
 
@@ -419,11 +523,6 @@ function enterMainViewAndRestoreWindowState(): boolean {
   return true
 }
 
-function setOverlayAlwaysOnTop(value: boolean): boolean {
-  overlayWindow?.setAlwaysOnTop(value)
-  return value
-}
-
 function applyMouseIgnoreState(): void {
   if (!overlayWindow || overlayWindow.isDestroyed()) {
     return
@@ -438,6 +537,80 @@ function applyMouseIgnoreState(): void {
   } catch (error) {
     console.error('[HeartDock] failed to update click-through:', error)
   }
+}
+
+function stopPureDisplayTopmostTimer(): void {
+  if (!pureDisplayTopmostTimer) {
+    return
+  }
+
+  clearInterval(pureDisplayTopmostTimer)
+  pureDisplayTopmostTimer = null
+}
+
+function reinforcePureDisplayTopmost(): void {
+  if (!overlayAlwaysOnTop || !pureDisplayTopmost || !overlayWindow || overlayWindow.isDestroyed()) {
+    return
+  }
+
+  try {
+    overlayWindow.setAlwaysOnTop(true, 'screen-saver')
+    overlayWindow.moveTop()
+  } catch (error) {
+    console.error('[HeartDock] failed to reinforce pure display topmost:', error)
+  }
+}
+
+function updatePureDisplayTopmostTimer(): void {
+  if (!overlayAlwaysOnTop || !pureDisplayTopmost) {
+    stopPureDisplayTopmostTimer()
+    return
+  }
+
+  if (pureDisplayTopmostTimer) {
+    return
+  }
+
+  pureDisplayTopmostTimer = setInterval(reinforcePureDisplayTopmost, PURE_DISPLAY_TOPMOST_REINFORCE_MS)
+}
+
+function applyOverlayAlwaysOnTop(): void {
+  if (!overlayWindow || overlayWindow.isDestroyed()) {
+    return
+  }
+
+  try {
+    if (!overlayAlwaysOnTop) {
+      overlayWindow.setAlwaysOnTop(false)
+      return
+    }
+
+    if (pureDisplayTopmost) {
+      overlayWindow.setAlwaysOnTop(true, 'screen-saver')
+      overlayWindow.moveTop()
+      return
+    }
+
+    overlayWindow.setAlwaysOnTop(true)
+  } catch (error) {
+    console.error('[HeartDock] failed to update always-on-top:', error)
+  }
+}
+
+function setOverlayAlwaysOnTop(value: boolean): boolean {
+  overlayAlwaysOnTop = value
+  applyOverlayAlwaysOnTop()
+  updatePureDisplayTopmostTimer()
+
+  return value
+}
+
+function setPureDisplayTopmost(value: boolean): boolean {
+  pureDisplayTopmost = value
+  applyOverlayAlwaysOnTop()
+  updatePureDisplayTopmostTimer()
+
+  return value
 }
 
 function setOverlayClickThrough(value: boolean): boolean {
@@ -511,6 +684,10 @@ function registerIpcHandlers(): void {
     return setOverlayAlwaysOnTop(value)
   })
 
+  ipcMain.handle('overlay:set-pure-display-topmost', (_event, value: boolean) => {
+    return setPureDisplayTopmost(value)
+  })
+
   ipcMain.handle('overlay:set-click-through', (_event, value: boolean) => {
     return setOverlayClickThrough(value)
   })
@@ -546,6 +723,14 @@ function registerIpcHandlers(): void {
 
   ipcMain.handle('overlay:select-display-background-image', () => {
     return selectDisplayBackgroundImage()
+  })
+
+  ipcMain.handle('overlay:export-config-file', (_event, content: unknown) => {
+    return exportConfigFile(content)
+  })
+
+  ipcMain.handle('overlay:import-config-file', () => {
+    return importConfigFile()
   })
 
   ipcMain.handle('overlay:move-window-by', (_event, deltaX: number, deltaY: number) => {
@@ -623,6 +808,10 @@ function registerIpcHandlers(): void {
 
   ipcMain.handle('set-always-on-top', (_event, value: boolean) => {
     return setOverlayAlwaysOnTop(value)
+  })
+
+  ipcMain.handle('set-pure-display-topmost', (_event, value: boolean) => {
+    return setPureDisplayTopmost(value)
   })
 
   ipcMain.handle('set-click-through', (_event, value: boolean) => {
@@ -745,6 +934,7 @@ function createOverlayWindow(): void {
   })
 
   overlayWindow.on('close', () => {
+    setPureDisplayTopmost(false)
     flushWindowState()
   })
 
@@ -811,5 +1001,6 @@ app.on('window-all-closed', () => {
 
 app.on('will-quit', () => {
   unlockClickThroughHotkey()
+  stopPureDisplayTopmostTimer()
   globalShortcut.unregisterAll()
 })

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -13,8 +13,20 @@ interface DisplayBackgroundImageResult {
   url: string
 }
 
+interface ConfigFileOpenResult {
+  content: string
+  fileName: string
+}
+
+interface ConfigFileSaveResult {
+  fileName: string
+  filePath: string
+}
+
 contextBridge.exposeInMainWorld('heartdock', {
   setAlwaysOnTop: (enabled: boolean) => ipcRenderer.invoke('overlay:set-always-on-top', enabled),
+  setPureDisplayTopmost: (enabled: boolean) =>
+    ipcRenderer.invoke('overlay:set-pure-display-topmost', enabled),
   setClickThrough: (enabled: boolean) => ipcRenderer.invoke('overlay:set-click-through', enabled),
   setHitTestPassthrough: (enabled: boolean) =>
     ipcRenderer.invoke('overlay:set-hit-test-passthrough', enabled),
@@ -30,6 +42,10 @@ contextBridge.exposeInMainWorld('heartdock', {
     ipcRenderer.invoke('overlay:move-window-by', deltaX, deltaY),
   selectDisplayBackgroundImage: (): Promise<DisplayBackgroundImageResult | null> =>
     ipcRenderer.invoke('overlay:select-display-background-image'),
+  exportConfigFile: (content: string): Promise<ConfigFileSaveResult | null> =>
+    ipcRenderer.invoke('overlay:export-config-file', content),
+  importConfigFile: (): Promise<ConfigFileOpenResult | null> =>
+    ipcRenderer.invoke('overlay:import-config-file'),
   onClickThroughChanged: (callback: (enabled: boolean) => void) => {
     const listener = (_event: Electron.IpcRendererEvent, enabled: boolean) => callback(enabled)
     ipcRenderer.on('overlay:click-through-changed', listener)

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -19,6 +19,7 @@ import {
   loadConfig,
   normalizeBpm,
   normalizeColor,
+  normalizeConfig,
   normalizeDisplayBackgroundImageOpacity,
   normalizeDisplayText,
   normalizeRefreshIntervalMs,
@@ -86,7 +87,10 @@ const displayStylePresetOptions: Array<SelectOption<DisplayStylePreset>> = [
   { value: 'glass', label: '柔和玻璃卡片', description: '半透明玻璃质感，适合日常桌面。' },
   { value: 'capsule', label: '圆角胶囊', description: '紧凑的圆角胶囊框，适合小尺寸悬浮。' },
   { value: 'neon', label: '霓虹直播框', description: '带弱发光边框，适合直播和录屏。' },
-  { value: 'kawaii', label: '二次元贴纸风', description: '粉蓝渐变、爱心和星星点缀，偏可爱风。' }
+  { value: 'kawaii', label: '二次元贴纸风', description: '粉蓝渐变、爱心和星星点缀，偏可爱风。' },
+  { value: 'aurora', label: '极光流光框', description: '冷暖光带边框，适合深色全屏叠加。' },
+  { value: 'mono', label: '极简描边框', description: '低开销细线框，适合游戏和长期显示。' },
+  { value: 'heartbeat', label: '心电监护框', description: '监护仪风格网格和心电线，适合运动数据展示。' }
 ]
 
 const appearanceModeOptions: Array<SelectOption<AppearanceMode>> = [
@@ -194,6 +198,14 @@ function getBleDeviceDisplayName(device: BleDevice): string {
   return cleanedName
 }
 
+function getImportedConfigCandidate(payload: unknown): unknown {
+  if (payload && typeof payload === 'object' && 'config' in payload) {
+    return (payload as { config?: unknown }).config
+  }
+
+  return payload
+}
+
 function App() {
   const initialConfigRef = useRef<HeartDockConfig | null>(null)
 
@@ -220,7 +232,10 @@ function App() {
     lastScreenX: 0,
     lastScreenY: 0,
     totalDeltaX: 0,
-    totalDeltaY: 0
+    totalDeltaY: 0,
+    animationFrameId: 0,
+    pendingDeltaX: 0,
+    pendingDeltaY: 0
   })
 
   const pureDragMovedRef = useRef(false)
@@ -352,6 +367,14 @@ function App() {
   useEffect(() => {
     window.heartdock.setAlwaysOnTop(config.alwaysOnTop)
   }, [config.alwaysOnTop])
+
+  useEffect(() => {
+    void window.heartdock.setPureDisplayTopmost(config.pureDisplay && config.alwaysOnTop)
+
+    return () => {
+      void window.heartdock.setPureDisplayTopmost(false)
+    }
+  }, [config.alwaysOnTop, config.pureDisplay])
 
   useEffect(() => {
     window.heartdock.setClickThrough(config.clickThrough)
@@ -833,10 +856,36 @@ function App() {
       lastScreenX: event.screenX,
       lastScreenY: event.screenY,
       totalDeltaX: 0,
-      totalDeltaY: 0
+      totalDeltaY: 0,
+      animationFrameId: 0,
+      pendingDeltaX: 0,
+      pendingDeltaY: 0
     }
 
     window.heartdock.setHitTestPassthrough(false)
+
+    const applyPendingPureDrag = (): void => {
+      const dragState = pureDragStateRef.current
+      dragState.animationFrameId = 0
+
+      if (!dragState.isDragging) {
+        dragState.pendingDeltaX = 0
+        dragState.pendingDeltaY = 0
+        return
+      }
+
+      const deltaX = dragState.pendingDeltaX
+      const deltaY = dragState.pendingDeltaY
+
+      if (deltaX === 0 && deltaY === 0) {
+        return
+      }
+
+      dragState.pendingDeltaX = 0
+      dragState.pendingDeltaY = 0
+
+      void window.heartdock.moveWindowBy(deltaX, deltaY)
+    }
 
     const handleMouseMove = (moveEvent: MouseEvent): void => {
       const dragState = pureDragStateRef.current
@@ -861,11 +910,28 @@ function App() {
         pureDragMovedRef.current = true
       }
 
-      void window.heartdock.moveWindowBy(deltaX, deltaY)
+      dragState.pendingDeltaX += deltaX
+      dragState.pendingDeltaY += deltaY
+
+      if (dragState.animationFrameId === 0) {
+        dragState.animationFrameId = window.requestAnimationFrame(applyPendingPureDrag)
+      }
     }
 
     const handleMouseUp = (upEvent: MouseEvent): void => {
-      pureDragStateRef.current.isDragging = false
+      const dragState = pureDragStateRef.current
+      dragState.isDragging = false
+
+      if (dragState.animationFrameId !== 0) {
+        window.cancelAnimationFrame(dragState.animationFrameId)
+        dragState.animationFrameId = 0
+      }
+
+      if (dragState.pendingDeltaX !== 0 || dragState.pendingDeltaY !== 0) {
+        void window.heartdock.moveWindowBy(dragState.pendingDeltaX, dragState.pendingDeltaY)
+        dragState.pendingDeltaX = 0
+        dragState.pendingDeltaY = 0
+      }
 
       window.removeEventListener('mousemove', handleMouseMove)
       window.removeEventListener('mouseup', handleMouseUp)
@@ -1407,6 +1473,7 @@ function App() {
     }
 
     setIsClosing(true)
+    void window.heartdock.setPureDisplayTopmost(false)
     void window.heartdock.setHitTestPassthrough(false)
     void window.heartdock.setClickThrough(false)
 
@@ -1432,6 +1499,82 @@ function App() {
     event.preventDefault()
     event.stopPropagation()
     showInteractionLockNotice()
+  }
+
+  const handleExportConfig = async (): Promise<void> => {
+    try {
+      const payload = {
+        app: 'HeartDock',
+        schemaVersion: 1,
+        exportedAt: new Date().toISOString(),
+        config
+      }
+      const result = await window.heartdock.exportConfigFile(JSON.stringify(payload, null, 2))
+
+      if (!result) {
+        return
+      }
+
+      window.alert(`已导出配置文件：${result.fileName}`)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : '导出配置文件失败。'
+      window.alert(message)
+    }
+  }
+
+  const handleImportConfig = async (): Promise<void> => {
+    try {
+      const result = await window.heartdock.importConfigFile()
+
+      if (!result) {
+        return
+      }
+
+      const parsed = JSON.parse(result.content) as unknown
+      const importedConfig = normalizeConfig(getImportedConfigCandidate(parsed))
+      const nextConfig: HeartDockConfig = {
+        ...importedConfig,
+        clickThrough: false,
+        pureDisplay: false,
+        showSettings: true
+      }
+      const nextBpm = normalizeBpm(nextConfig.manualBpm)
+
+      void disconnectBleDevice('已载入配置文件，BLE 连接已关闭。')
+      void window.heartdock.setPureDisplayTopmost(false)
+      void window.heartdock.setHitTestPassthrough(false)
+      void window.heartdock.setClickThrough(false)
+
+      sourceModeRef.current = nextConfig.heartRateSourceMode
+      normalWindowBoundsRef.current = null
+
+      if (nextConfig.heartRateSourceMode === 'mock') {
+        sourceRef.current = new MockHeartRateSource()
+        setBpm(sourceRef.current.next())
+      } else {
+        setBpm(nextBpm)
+      }
+
+      if (nextConfig.heartRateSourceMode === 'ble') {
+        setBleStatus('idle')
+        setBleDeviceName('')
+        setHasBleReconnectDevice(false)
+        setBleMessage('已载入配置文件。请重新连接 BLE 心率设备后开始接收实时心率。')
+      }
+
+      setManualInput(String(nextBpm))
+      setRefreshIntervalInput(String(normalizeRefreshIntervalMs(nextConfig.refreshIntervalMs)))
+      setConfig(nextConfig)
+      window.alert(`已载入配置文件：${result.fileName}`)
+    } catch (error) {
+      const message =
+        error instanceof SyntaxError
+          ? '配置文件不是有效的 JSON 文件。'
+          : error instanceof Error
+            ? error.message
+            : '载入配置文件失败。'
+      window.alert(message)
+    }
   }
 
   const handleResetConfig = (): void => {
@@ -1925,6 +2068,35 @@ function App() {
               <p className="hint">
                 开启后，HeartDock 会拦截鼠标点击，不会操作 HeartDock，也不会点到底层窗口；需要再次操作时，请按 Ctrl + Shift + H 解锁。
               </p>
+
+              <div className="settings-section">
+                <div className="section-heading">
+                  <span>配置文件</span>
+                  <small>导出当前显示和数据源设置，或载入之前保存的 JSON 配置文件。</small>
+                </div>
+
+                <div className="config-file-actions">
+                  <button
+                    className="secondary-button"
+                    type="button"
+                    onClick={() => void handleExportConfig()}
+                  >
+                    导出配置
+                  </button>
+
+                  <button
+                    className="secondary-button"
+                    type="button"
+                    onClick={() => void handleImportConfig()}
+                  >
+                    载入配置
+                  </button>
+                </div>
+
+                <p className="hint">
+                  载入配置时会自动关闭纯享模式和鼠标禁止交互，避免载入后误锁窗口；BLE 设备需要重新连接。
+                </p>
+              </div>
 
               <div className="project-links-panel">
                 <div className="section-heading">

--- a/src/renderer/src/config.ts
+++ b/src/renderer/src/config.ts
@@ -8,7 +8,16 @@ export type HeartRateSourceMode = 'mock' | 'manual' | 'ble'
 export type HeartRateColorMode = 'range' | 'fixed'
 export type DisplayGlowLevel = 'off' | 'soft' | 'medium' | 'strong'
 export type DisplayBackgroundImageFit = 'contain' | 'cover' | 'stretch'
-export type DisplayStylePreset = 'none' | 'glass' | 'capsule' | 'neon' | 'kawaii' | 'image-card'
+export type DisplayStylePreset =
+  | 'none'
+  | 'glass'
+  | 'capsule'
+  | 'neon'
+  | 'kawaii'
+  | 'aurora'
+  | 'mono'
+  | 'heartbeat'
+  | 'image-card'
 
 export interface HeartDockConfig {
   heartRateSourceMode: HeartRateSourceMode
@@ -76,6 +85,28 @@ export function normalizeBpm(value: number): number {
   return Math.min(Math.max(Math.round(value), 30), 240)
 }
 
+export function normalizeHeartRateSourceMode(value: unknown): HeartRateSourceMode {
+  return value === 'mock' || value === 'manual' || value === 'ble'
+    ? value
+    : defaultConfig.heartRateSourceMode
+}
+
+export function normalizeFontSize(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return defaultConfig.fontSize
+  }
+
+  return Math.min(Math.max(Math.round(value), 36), 96)
+}
+
+export function normalizeBackgroundOpacity(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return defaultConfig.backgroundOpacity
+  }
+
+  return Math.min(Math.max(value, 0), 1)
+}
+
 export function normalizeRefreshIntervalMs(value: number): number {
   if (!Number.isFinite(value)) {
     return defaultConfig.refreshIntervalMs
@@ -132,6 +163,9 @@ export function normalizeDisplayStylePreset(value: unknown): DisplayStylePreset 
     value === 'capsule' ||
     value === 'neon' ||
     value === 'kawaii' ||
+    value === 'aurora' ||
+    value === 'mono' ||
+    value === 'heartbeat' ||
     value === 'image-card'
     ? value
     : defaultConfig.displayStylePreset
@@ -173,48 +207,7 @@ export function loadConfig(): HeartDockConfig {
   }
 
   try {
-    const parsed = JSON.parse(raw) as Partial<HeartDockConfig>
-
-    return {
-      ...createDefaultConfig(),
-      ...parsed,
-      manualBpm: normalizeBpm(parsed.manualBpm ?? defaultConfig.manualBpm),
-      refreshIntervalMs: normalizeRefreshIntervalMs(
-        parsed.refreshIntervalMs ?? defaultConfig.refreshIntervalMs
-      ),
-      clickThrough: Boolean(parsed.clickThrough ?? defaultConfig.clickThrough),
-      showSettings: Boolean(parsed.showSettings ?? defaultConfig.showSettings),
-      pureDisplay: Boolean(parsed.pureDisplay ?? defaultConfig.pureDisplay),
-      prefixText: normalizeDisplayText(parsed.prefixText, defaultConfig.prefixText, 8),
-      unitText: normalizeDisplayText(parsed.unitText, defaultConfig.unitText, 8),
-      colorMode: normalizeColorMode(parsed.colorMode),
-      fixedColor: normalizeColor(parsed.fixedColor, defaultConfig.fixedColor),
-      glowLevel: normalizeGlowLevel(parsed.glowLevel),
-      colorRules: normalizeColorRules(parsed.colorRules),
-      displayBackgroundImageEnabled: Boolean(
-        parsed.displayBackgroundImageEnabled ?? defaultConfig.displayBackgroundImageEnabled
-      ),
-      displayBackgroundImageUrl: normalizeDisplayText(
-        parsed.displayBackgroundImageUrl,
-        defaultConfig.displayBackgroundImageUrl,
-        2048
-      ),
-      displayBackgroundImageAssetFileName: normalizeDisplayText(
-        parsed.displayBackgroundImageAssetFileName,
-        defaultConfig.displayBackgroundImageAssetFileName,
-        256
-      ),
-      displayBackgroundImageName: normalizeDisplayText(
-        parsed.displayBackgroundImageName,
-        defaultConfig.displayBackgroundImageName,
-        128
-      ),
-      displayBackgroundImageOpacity: normalizeDisplayBackgroundImageOpacity(
-        parsed.displayBackgroundImageOpacity
-      ),
-      displayBackgroundImageFit: normalizeDisplayBackgroundImageFit(parsed.displayBackgroundImageFit),
-      displayStylePreset: normalizeDisplayStylePreset(parsed.displayStylePreset)
-    }
+    return normalizeConfig(JSON.parse(raw))
   } catch {
     return createDefaultConfig()
   }
@@ -229,6 +222,11 @@ export function createDefaultConfig(): HeartDockConfig {
     ...defaultConfig,
     refreshIntervalMs: normalizeRefreshIntervalMs(defaultConfig.refreshIntervalMs),
     manualBpm: normalizeBpm(defaultConfig.manualBpm),
+    heartRateSourceMode: normalizeHeartRateSourceMode(defaultConfig.heartRateSourceMode),
+    mockPaused: Boolean(defaultConfig.mockPaused),
+    fontSize: normalizeFontSize(defaultConfig.fontSize),
+    backgroundOpacity: normalizeBackgroundOpacity(defaultConfig.backgroundOpacity),
+    alwaysOnTop: Boolean(defaultConfig.alwaysOnTop),
     clickThrough: defaultConfig.clickThrough,
     showSettings: defaultConfig.showSettings,
     pureDisplay: defaultConfig.pureDisplay,
@@ -245,5 +243,59 @@ export function createDefaultConfig(): HeartDockConfig {
     displayBackgroundImageOpacity: defaultConfig.displayBackgroundImageOpacity,
     displayBackgroundImageFit: defaultConfig.displayBackgroundImageFit,
     displayStylePreset: defaultConfig.displayStylePreset
+  }
+}
+
+export function normalizeConfig(value: unknown): HeartDockConfig {
+  if (!value || typeof value !== 'object') {
+    return createDefaultConfig()
+  }
+
+  const parsed = value as Partial<HeartDockConfig>
+
+  return {
+    ...createDefaultConfig(),
+    ...parsed,
+    heartRateSourceMode: normalizeHeartRateSourceMode(parsed.heartRateSourceMode),
+    mockPaused: Boolean(parsed.mockPaused ?? defaultConfig.mockPaused),
+    manualBpm: normalizeBpm(parsed.manualBpm ?? defaultConfig.manualBpm),
+    refreshIntervalMs: normalizeRefreshIntervalMs(
+      parsed.refreshIntervalMs ?? defaultConfig.refreshIntervalMs
+    ),
+    fontSize: normalizeFontSize(parsed.fontSize),
+    backgroundOpacity: normalizeBackgroundOpacity(parsed.backgroundOpacity),
+    alwaysOnTop: Boolean(parsed.alwaysOnTop ?? defaultConfig.alwaysOnTop),
+    clickThrough: Boolean(parsed.clickThrough ?? defaultConfig.clickThrough),
+    showSettings: Boolean(parsed.showSettings ?? defaultConfig.showSettings),
+    pureDisplay: Boolean(parsed.pureDisplay ?? defaultConfig.pureDisplay),
+    prefixText: normalizeDisplayText(parsed.prefixText, defaultConfig.prefixText, 8),
+    unitText: normalizeDisplayText(parsed.unitText, defaultConfig.unitText, 8),
+    colorMode: normalizeColorMode(parsed.colorMode),
+    fixedColor: normalizeColor(parsed.fixedColor, defaultConfig.fixedColor),
+    glowLevel: normalizeGlowLevel(parsed.glowLevel),
+    colorRules: normalizeColorRules(parsed.colorRules),
+    displayBackgroundImageEnabled: Boolean(
+      parsed.displayBackgroundImageEnabled ?? defaultConfig.displayBackgroundImageEnabled
+    ),
+    displayBackgroundImageUrl: normalizeDisplayText(
+      parsed.displayBackgroundImageUrl,
+      defaultConfig.displayBackgroundImageUrl,
+      2048
+    ),
+    displayBackgroundImageAssetFileName: normalizeDisplayText(
+      parsed.displayBackgroundImageAssetFileName,
+      defaultConfig.displayBackgroundImageAssetFileName,
+      256
+    ),
+    displayBackgroundImageName: normalizeDisplayText(
+      parsed.displayBackgroundImageName,
+      defaultConfig.displayBackgroundImageName,
+      128
+    ),
+    displayBackgroundImageOpacity: normalizeDisplayBackgroundImageOpacity(
+      parsed.displayBackgroundImageOpacity
+    ),
+    displayBackgroundImageFit: normalizeDisplayBackgroundImageFit(parsed.displayBackgroundImageFit),
+    displayStylePreset: normalizeDisplayStylePreset(parsed.displayStylePreset)
   }
 }

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -1854,6 +1854,78 @@ textarea,
   color: rgba(255, 255, 255, 0.92);
 }
 
+.display-style-aurora {
+  overflow: hidden;
+  border: 1px solid rgba(165, 180, 252, 0.42) !important;
+  border-radius: 30px;
+  background:
+    radial-gradient(circle at 18% 18%, rgba(34, 211, 238, 0.24), transparent 36%),
+    radial-gradient(circle at 86% 74%, rgba(251, 113, 133, 0.18), transparent 34%),
+    linear-gradient(145deg, rgba(8, 13, 28, 0.76), rgba(20, 28, 46, 0.58)) !important;
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.08),
+    0 16px 34px rgba(15, 23, 42, 0.22),
+    0 0 34px rgba(34, 211, 238, 0.13) !important;
+}
+
+.display-style-aurora::before {
+  content: "";
+  inset: -46%;
+  z-index: 1;
+  background:
+    conic-gradient(from 90deg, rgba(34, 211, 238, 0), rgba(34, 211, 238, 0.2), rgba(251, 113, 133, 0.16), rgba(250, 204, 21, 0.14), rgba(34, 211, 238, 0));
+  opacity: 0.58;
+  transform: rotate(10deg);
+}
+
+.display-style-mono {
+  border: 1px solid rgba(226, 232, 240, 0.34) !important;
+  border-radius: 18px;
+  background: rgba(2, 6, 23, 0.44) !important;
+  box-shadow:
+    inset 0 0 0 1px rgba(15, 23, 42, 0.28),
+    0 10px 22px rgba(2, 6, 23, 0.16) !important;
+}
+
+.normal-display-frame.display-style-mono.has-display-frame,
+.pure-display-frame.display-style-mono.has-display-frame {
+  min-height: 0;
+  padding: 16px 24px;
+}
+
+.display-style-heartbeat {
+  overflow: hidden;
+  border: 1px solid rgba(52, 211, 153, 0.42) !important;
+  border-radius: 22px;
+  background:
+    linear-gradient(rgba(52, 211, 153, 0.08) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(52, 211, 153, 0.08) 1px, transparent 1px),
+    linear-gradient(135deg, rgba(2, 20, 18, 0.82), rgba(8, 24, 28, 0.66)) !important;
+  background-size: 18px 18px, 18px 18px, auto;
+  box-shadow:
+    inset 0 0 0 1px rgba(187, 247, 208, 0.08),
+    0 0 26px rgba(20, 184, 166, 0.13),
+    0 12px 28px rgba(2, 6, 23, 0.2) !important;
+}
+
+.display-style-heartbeat::after {
+  content: "";
+  left: 18px;
+  right: 18px;
+  bottom: 14px;
+  z-index: 1;
+  height: 2px;
+  border-radius: 999px;
+  background:
+    linear-gradient(90deg, transparent 0 8%, rgba(52, 211, 153, 0.76) 8% 17%, transparent 17% 24%, rgba(52, 211, 153, 0.72) 24% 27%, transparent 27% 31%, rgba(52, 211, 153, 0.84) 31% 35%, transparent 35% 100%);
+  filter: drop-shadow(0 0 8px rgba(52, 211, 153, 0.48));
+}
+
+.pure-display-frame.display-style-heartbeat.has-display-frame {
+  min-height: 118px;
+  padding: 24px 28px 30px;
+}
+
 .display-style-image-card.has-display-frame,
 .display-style-image-card.has-display-background {
   border: 0 !important;
@@ -2032,10 +2104,29 @@ textarea,
 .pure-display-frame .pure-heart-row {
   pointer-events: auto !important;
   cursor: grab;
+  user-select: none;
+  touch-action: none;
+  will-change: transform;
 }
 
 .pure-display-frame .pure-heart-row:active {
   cursor: grabbing;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .display-style-aurora::before {
+    animation: aurora-frame-sweep 10s linear infinite;
+  }
+}
+
+@keyframes aurora-frame-sweep {
+  from {
+    transform: rotate(10deg);
+  }
+
+  to {
+    transform: rotate(370deg);
+  }
 }
 
 
@@ -2081,6 +2172,16 @@ textarea,
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 10px;
+}
+
+.config-file-actions {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.config-file-actions .secondary-button {
+  width: 100%;
 }
 
 .project-link-card {
@@ -2397,6 +2498,7 @@ textarea,
 }
 
 @media (max-width: 640px) {
+  .config-file-actions,
   .project-link-grid,
   .first-run-notice-link-grid {
     grid-template-columns: 1fr;

--- a/src/renderer/src/vite-env.d.ts
+++ b/src/renderer/src/vite-env.d.ts
@@ -13,8 +13,19 @@ interface DisplayBackgroundImageResult {
   url: string
 }
 
+interface ConfigFileOpenResult {
+  content: string
+  fileName: string
+}
+
+interface ConfigFileSaveResult {
+  fileName: string
+  filePath: string
+}
+
 interface HeartDockApi {
   setAlwaysOnTop: (enabled: boolean) => Promise<boolean>
+  setPureDisplayTopmost: (enabled: boolean) => Promise<boolean>
   setClickThrough: (enabled: boolean) => Promise<boolean>
   setHitTestPassthrough: (enabled: boolean) => Promise<boolean>
   getClickThrough: () => Promise<boolean>
@@ -26,6 +37,8 @@ interface HeartDockApi {
   setWindowBounds: (bounds: HeartDockWindowBounds) => Promise<boolean>
   moveWindowBy: (deltaX: number, deltaY: number) => Promise<boolean>
   selectDisplayBackgroundImage: () => Promise<DisplayBackgroundImageResult | null>
+  exportConfigFile: (content: string) => Promise<ConfigFileSaveResult | null>
+  importConfigFile: () => Promise<ConfigFileOpenResult | null>
   onClickThroughChanged: (callback: (enabled: boolean) => void) => () => void
 }
 


### PR DESCRIPTION
## 变更内容
- 纯享模式 + 始终置顶时启用增强置顶，尽量保持在全屏 / 无边框全屏应用上方显示。
- 纯享模式拖动改为逐帧合并位移，减少 mousemove 高频 IPC，改善跟手度和流畅度。
- 新增 3 个显示框样式：极光流光框、极简描边框、心电监护框。
- 新增配置文件导出 / 载入功能，支持 JSON 配置文件保存和恢复。
- 导入配置时增加 normalize 校验，并自动关闭纯享模式、鼠标禁止交互和 BLE 连接，避免误锁或状态残留。

## 验证
- 用户本地测试通过。
- `npm run typecheck` 通过。
- `npm run build` 通过。
- `git diff --check` 通过。

## 关联 Issue
- Closes #59
- Related #58